### PR TITLE
Fix modal in full-screen mode

### DIFF
--- a/package/@resource.json
+++ b/package/@resource.json
@@ -20,6 +20,7 @@
     "radium": "^0.24.0",
     "radium-starter": "^0.11.7",
     "react-day-picker": "^7.2.4",
+    "react-full-screen": "^0.2.4",
     "react-md-spinner": "^0.3.0",
     "react-modal": "^3.6.1",
     "react-router-dom": "^4.2.2"

--- a/package/src/modal/components/container.js
+++ b/package/src/modal/components/container.js
@@ -5,7 +5,7 @@ import ReactModal from 'react-modal';
 
 import {Style} from 'radium';
 
-export const Container = ({onClose, children, ...props}) => {
+export const Container = ({onClose, children, rootRef, ...props}) => {
   return (
     <RadiumStarter>
       {(t, s) => (
@@ -21,6 +21,7 @@ export const Container = ({onClose, children, ...props}) => {
               '.ReactModal__Content--before-close': {opacity: 0}
             }}
           />
+          {/* Mount React Modal inside a parent div, instead of `document.body`, using `parentSelector` option */}
           <ReactModal
             isOpen
             style={generateStyle(t, s, props)}
@@ -29,6 +30,7 @@ export const Container = ({onClose, children, ...props}) => {
               return onClose(false);
             }}
             ariaHideApp={false}
+            parentSelector={() => rootRef.current}
           >
             {children}
           </ReactModal>
@@ -39,7 +41,8 @@ export const Container = ({onClose, children, ...props}) => {
 };
 Container.propTypes = {
   onClose: PropTypes.func,
-  children: PropTypes.node
+  children: PropTypes.node,
+  rootRef: PropTypes.any.isRequired
 };
 
 /*

--- a/package/src/modal/components/stack.js
+++ b/package/src/modal/components/stack.js
@@ -3,14 +3,23 @@ import React from 'react';
 import {Container} from './container';
 import {Dialog} from './dialog';
 
-export const Stack = ({modal}) => {
-  return modal.getStack().map(({options}, index) => {
-    const {render, ...otherOptions} = options;
-    const Content = render || Dialog;
+export class Stack extends React.Component {
+  root = React.createRef(); // used to mount ReactModal inside the <Fullscreen> container
+
+  render() {
+    const {modal} = this.props;
     return (
-      <Container key={index} onClose={modal.close} {...otherOptions}>
-        <Content {...otherOptions} close={modal.close} />
-      </Container>
+      <div ref={this.root}>
+        {modal.getStack().map(({options}, index) => {
+          const {render, ...otherOptions} = options;
+          const Content = render || Dialog;
+          return (
+            <Container key={index} onClose={modal.close} rootRef={this.root} {...otherOptions}>
+              <Content {...otherOptions} close={modal.close} />
+            </Container>
+          );
+        })}
+      </div>
     );
-  });
-};
+  }
+}

--- a/package/src/root.js
+++ b/package/src/root.js
@@ -3,6 +3,7 @@ import PropTypes from 'prop-types';
 import {Style} from 'radium';
 import RadiumStarter, {RadiumStarterRoot} from 'radium-starter';
 import subscribe from '@ministate/react';
+import Fullscreen from 'react-full-screen';
 
 import {LocaleProvider} from './locale-context';
 import {AppProvider} from './app-context';
@@ -37,15 +38,23 @@ const Wrapper = props => {
     <RadiumStarterRoot theme={theme} styles={styles}>
       <AppProvider app={app}>
         <LocaleProvider locale={app.getLocale()}>
-          <RadiumStarter>
-            {(t, s) => (
-              <React.Fragment>
-                <Style rules={globalStyles(t, s)} />
-                {children}
-              </React.Fragment>
-            )}
-          </RadiumStarter>
-          {app.getModal().createElement()}
+          <Fullscreen
+            enabled={app.state.isFullscreen}
+            onChange={value => {
+              app.setIsFullscreen(value);
+            }}
+          >
+            <RadiumStarter>
+              {(t, s) => (
+                <React.Fragment>
+                  <Style rules={globalStyles(t, s)} />
+                  {children}
+                </React.Fragment>
+              )}
+            </RadiumStarter>
+            {/* Modal element must be mounted inside <Fullscreen> */}
+            {app.getModal().createElement()}
+          </Fullscreen>
         </LocaleProvider>
       </AppProvider>
     </RadiumStarterRoot>


### PR DESCRIPTION
## Goal

Fix a bug found in Pidport Datastore: when the image viewer is open in full-screen mode, the modal doesn't show correctly.

How to check the correction:

- Go to Pidport Datastore > Scans
- Open a scan record
- Click on the image to open the ImageViewer component
- Enter the fullscreen mode by clicking on the icon, in the left sidebar
- Click on the pen icon to open the "Choose an annotation label" modal (see screenshot)

## Screenshot

<img width="1005" alt="image" src="https://user-images.githubusercontent.com/5546996/54665820-6adc2500-4b2b-11e9-844c-3255b2c38ce4.png">

## Implementation

- Add `react-full-screen` dependency
- Update `<Root>` to wrap the application inside the `<Fullscreen>` container
- Call `react-modal` with the `parentSelector` option, passing an element that is mounted inside the `<Fullscreen>` container

## Related PRs:

- https://github.com/medmain/medmain-js/pull/29
- https://github.com/medmain/medmain-images/pull/31

