### PR TITLE
New scrollable `<List>` component (0.2.0)

### DIFF
--- a/package/@resource.json
+++ b/package/@resource.json
@@ -1,7 +1,7 @@
 {
   "@import": "medmain/npm-package#^0.1.0",
   "name": "@medmain/react-ui-kit",
-  "version": "0.1.3",
+  "version": "0.2.0",
   "description": "React shared components used in Medmain web applications",
   "contributors": [
     "Manuel Vila <hi@mvila.me>",

--- a/package/src/list.js
+++ b/package/src/list.js
@@ -32,7 +32,7 @@ export class List extends React.Component {
 
   static defaultProps = {
     bodyRows: {},
-    columnDefaults: {},
+    columnDefaults: {shrink: false, truncate: false},
     onSelect: () => {}
   };
 
@@ -56,13 +56,6 @@ export class List extends React.Component {
 
     onSelect(selection);
   };
-
-  getColumnDefaults() {
-    const {
-      columnDefaults: {shrink = true, truncate = false}
-    } = this.props;
-    return {shrink, truncate};
-  }
 
   renderCellContent({content, item, path}) {
     if (content !== undefined) {
@@ -90,7 +83,10 @@ export class List extends React.Component {
     } = this.props;
 
     const columns = rawColumns.map(normalizeColumnDefinition);
-    const columnDefaults = this.getColumnDefaults();
+    const columnDefaults = {
+      ...this.constructor.defaultProps.columnDefaults,
+      ...this.props.columnDefaults
+    };
     const enableScrolling = columnDefaults.shrink === false; // no scrolling by default
     const hasFooter = columns.some(column => column.footerCell) && items.length > 0;
     const hasTruncatedColumn = columnDefaults.truncate || columns.some(column => column.truncate);

--- a/package/src/list.js
+++ b/package/src/list.js
@@ -1,6 +1,7 @@
 import React from 'react';
 import PropTypes from 'prop-types';
 import {withRadiumStarter} from 'radium-starter';
+import get from 'lodash/get';
 
 import {CheckboxInput} from './form';
 import {withLocale} from './locale-context';
@@ -62,6 +63,16 @@ export class List extends React.Component {
     return {shrink, truncate};
   }
 
+  renderCellContent({render, item, path}) {
+    if (render !== undefined) {
+      return evaluate(render, item); // caution: `render` can be an empty string
+    }
+    if (item) {
+      return get(item, path); // get a property from a nested object using a "dot path"
+    }
+    return path;
+  }
+
   render() {
     const {
       columns,
@@ -119,7 +130,7 @@ export class List extends React.Component {
                   width = columnDefaults.width,
                   truncate = columnDefaults.truncate,
                   style: columnStyle = columnDefaults.style,
-                  headerCell: {title, style: cellStyle, render}
+                  headerCell: {title, style: cellStyle, render} = {}
                 }) => {
                   const isCurrentOrder = orderBy === path;
                   if (isCurrentOrder) {
@@ -143,7 +154,7 @@ export class List extends React.Component {
                         ...cellStyle
                       }}
                     >
-                      {evaluate(render)}
+                      {this.renderCellContent({render, path})}
                       {isCurrentOrder && <SortMarker direction={orderDirection} />}
                     </ListCell>
                   );
@@ -179,7 +190,7 @@ export class List extends React.Component {
                       width = columnDefaults.width,
                       truncate = columnDefaults.truncate,
                       style: columnStyle = columnDefaults.style,
-                      bodyCell: {title, style: cellStyle, render}
+                      bodyCell: {title, style: cellStyle, render} = {}
                     }) => {
                       return (
                         <ListCell
@@ -194,7 +205,7 @@ export class List extends React.Component {
                           truncate={truncate}
                           style={{width, ...columnStyle, ...evaluate(cellStyle, item, index)}}
                         >
-                          {evaluate(render, item)}
+                          {this.renderCellContent({render, item, path})}
                         </ListCell>
                       );
                     }
@@ -214,7 +225,7 @@ export class List extends React.Component {
                     width = columnDefaults.width,
                     truncate = columnDefaults.truncate,
                     style: columnStyle = columnDefaults.style,
-                    footerCell: {style: cellStyle, title, render}
+                    footerCell: {style: cellStyle, title, render} = {}
                   }) => {
                     return (
                       <ListCell
@@ -227,7 +238,7 @@ export class List extends React.Component {
                           ...cellStyle
                         }}
                       >
-                        {evaluate(render)}
+                        {this.renderCellContent({render, path})}
                       </ListCell>
                     );
                   }

--- a/package/src/list.js
+++ b/package/src/list.js
@@ -93,9 +93,9 @@ export class List extends React.Component {
     const hasFooter = columns.some(column => column.footerCell) && items.length > 0;
     const hasTruncatedColumn = columnDefaults.truncate || columns.some(column => column.truncate);
 
-    const getCellTitle = ({item, title, render, truncate}) => {
-      if (title) {
-        return evaluate(title, item);
+    const getCellTooltipLabel = ({item, tooltip, render, truncate}) => {
+      if (tooltip) {
+        return evaluate(tooltip, item);
       }
       if (truncate) {
         const renderedContent = evaluate(render, item);
@@ -130,7 +130,7 @@ export class List extends React.Component {
                   width = columnDefaults.width,
                   truncate = columnDefaults.truncate,
                   style: columnStyle = columnDefaults.style,
-                  headerCell: {title, style: cellStyle, render} = {}
+                  headerCell: {tooltip, style: cellStyle, render} = {}
                 }) => {
                   const isCurrentOrder = orderBy === path;
                   if (isCurrentOrder) {
@@ -146,7 +146,7 @@ export class List extends React.Component {
                           onHeaderClick(path);
                         })
                       }
-                      title={getCellTitle({title, render, truncate})}
+                      tooltip={getCellTooltipLabel({tooltip, render, truncate})}
                       truncate={truncate}
                       style={{
                         width,
@@ -190,7 +190,7 @@ export class List extends React.Component {
                       width = columnDefaults.width,
                       truncate = columnDefaults.truncate,
                       style: columnStyle = columnDefaults.style,
-                      bodyCell: {title, style: cellStyle, render} = {}
+                      bodyCell: {tooltip, style: cellStyle, render} = {}
                     }) => {
                       return (
                         <ListCell
@@ -201,7 +201,7 @@ export class List extends React.Component {
                               onItemClick(item, path);
                             })
                           }
-                          title={getCellTitle({item, title, render, truncate})}
+                          tooltip={getCellTooltipLabel({item, tooltip, render, truncate})}
                           truncate={truncate}
                           style={{width, ...columnStyle, ...evaluate(cellStyle, item, index)}}
                         >
@@ -225,12 +225,12 @@ export class List extends React.Component {
                     width = columnDefaults.width,
                     truncate = columnDefaults.truncate,
                     style: columnStyle = columnDefaults.style,
-                    footerCell: {style: cellStyle, title, render} = {}
+                    footerCell: {style: cellStyle, tooltip, render} = {}
                   }) => {
                     return (
                       <ListCell
                         key={path}
-                        title={getCellTitle({title, render, truncate})}
+                        tooltip={getCellTooltipLabel({tooltip, render, truncate})}
                         truncate={truncate}
                         style={{
                           width,
@@ -437,7 +437,7 @@ export class ListRow extends React.Component {
 export class ListCell extends React.Component {
   static propTypes = {
     onClick: PropTypes.func,
-    title: PropTypes.string,
+    tooltip: PropTypes.string,
     truncate: PropTypes.bool,
     style: PropTypes.object,
     theme: PropTypes.object.isRequired,
@@ -446,7 +446,7 @@ export class ListCell extends React.Component {
   };
 
   render() {
-    let {onClick, title, truncate, style, children, styles: s, theme: t} = this.props;
+    let {onClick, tooltip, truncate, style, children, styles: s, theme: t} = this.props;
 
     if (onClick) {
       style = {cursor: 'pointer', ...style};
@@ -478,7 +478,7 @@ export class ListCell extends React.Component {
           return (
             <td
               onClick={onClick}
-              title={title}
+              title={tooltip}
               style={{
                 padding: '8px',
                 verticalAlign: 'middle',

--- a/package/src/list.js
+++ b/package/src/list.js
@@ -262,7 +262,7 @@ function normalizeColumnDefinition({headerCell, bodyCell, footerCell, ...colDefi
     ...colDefinition,
     headerCell: normalizeCellDefinition(headerCell),
     bodyCell: normalizeCellDefinition(bodyCell),
-    footerCell: normalizeCellDefinition(footerCell)
+    ...(footerCell !== undefined && {footerCell: normalizeCellDefinition(footerCell)})
   };
 }
 

--- a/playground/doczrc.js
+++ b/playground/doczrc.js
@@ -1,5 +1,5 @@
 export default {
-  title: 'Medmain Playground',
+  title: 'Medmain React UI Kit',
   description:
     'A playground to visualize and test Medmain React components shared in `@medmain/react-ui-kit` package',
   codeSandbox: false,

--- a/playground/package.json
+++ b/playground/package.json
@@ -11,6 +11,7 @@
     "@babel/plugin-proposal-class-properties": "^7.3.3",
     "@babel/plugin-proposal-decorators": "^7.3.0",
     "@medmain/base-frontend": "^0.1.66",
+    "@medmain/core": "^0.2.0",
     "@medmain/react-ui-kit": "^0.1.0",
     "docz": "^0.13.7",
     "docz-theme-default": "^0.13.7",

--- a/playground/src/components/vertical-container.js
+++ b/playground/src/components/vertical-container.js
@@ -1,0 +1,12 @@
+import React from 'react';
+import PropTypes from 'prop-types';
+
+export const VerticalContainer = ({height = 200, children}) => {
+  return (
+    <div style={{flexGrow: 1, display: 'flex', flexDirection: 'column', height}}>{children}</div>
+  );
+};
+VerticalContainer.propTypes = {
+  height: PropTypes.number,
+  children: PropTypes.node.isRequired
+};

--- a/playground/src/docs/list-helpers/list-long-content.js
+++ b/playground/src/docs/list-helpers/list-long-content.js
@@ -7,50 +7,50 @@ export const columns = [
     path: 'reference',
     width: '50px',
     headerCell: {
-      render: () => 'Ref'
+      content: () => 'Ref'
     },
     bodyCell: {
-      render: item => item.reference
+      content: item => item.reference
     }
   },
   {
     path: 'patient',
     width: '100px',
     headerCell: {
-      render: () => `Patient's name`
+      content: () => `Patient's name`
     },
     bodyCell: {
-      render: item => item.patientName
+      content: item => item.patientName
     }
   },
   {
     path: 'organ',
     width: '100px',
     headerCell: {
-      render: () => `Organ`
+      content: () => `Organ`
     },
     bodyCell: {
-      render: item => item.organ
+      content: item => item.organ
     }
   },
   {
     path: 'disease',
     width: '100px',
     headerCell: {
-      render: () => `Disease`
+      content: () => `Disease`
     },
     bodyCell: {
-      render: item => item.disease
+      content: item => item.disease
     }
   },
   {
     path: 'tags',
     width: '100px',
     headerCell: {
-      render: () => `Tags`
+      content: () => `Tags`
     },
     bodyCell: {
-      render: item =>
+      content: item =>
         item.tags.map(tag => (
           <Badge style={{marginRight: '0.2rem', marginBottom: '0.2rem'}} key={tag}>
             {tag}
@@ -62,30 +62,30 @@ export const columns = [
     path: 'filename',
     width: '100px',
     headerCell: {
-      render: () => `Filename`
+      content: () => `Filename`
     },
     bodyCell: {
-      render: item => item.filename
+      content: item => item.filename
     }
   },
   {
     path: 'size',
     width: '50px',
     headerCell: {
-      render: () => `Size`
+      content: () => `Size`
     },
     bodyCell: {
-      render: item => item.size
+      content: item => item.size
     }
   },
   {
     path: 'addedOn',
     width: '150px',
     headerCell: {
-      render: () => `Added on`
+      content: () => `Added on`
     },
     bodyCell: {
-      render: item => item.addedOn
+      content: item => item.addedOn
     }
   }
 ];

--- a/playground/src/docs/list-helpers/list-long-content.js
+++ b/playground/src/docs/list-helpers/list-long-content.js
@@ -1,0 +1,116 @@
+import React from 'react';
+
+import {Badge} from '@medmain/react-ui-kit';
+
+export const columns = [
+  {
+    path: 'reference',
+    width: '50px',
+    headerCell: {
+      render: () => 'Ref'
+    },
+    bodyCell: {
+      render: item => item.reference
+    }
+  },
+  {
+    path: 'patient',
+    width: '100px',
+    headerCell: {
+      render: () => `Patient's name`
+    },
+    bodyCell: {
+      render: item => item.patientName
+    }
+  },
+  {
+    path: 'organ',
+    width: '100px',
+    headerCell: {
+      render: () => `Organ`
+    },
+    bodyCell: {
+      render: item => item.organ
+    }
+  },
+  {
+    path: 'disease',
+    width: '100px',
+    headerCell: {
+      render: () => `Disease`
+    },
+    bodyCell: {
+      render: item => item.disease
+    }
+  },
+  {
+    path: 'tags',
+    width: '100px',
+    headerCell: {
+      render: () => `Tags`
+    },
+    bodyCell: {
+      render: item =>
+        item.tags.map(tag => (
+          <Badge style={{marginRight: '0.2rem', marginBottom: '0.2rem'}} key={tag}>
+            {tag}
+          </Badge>
+        ))
+    }
+  },
+  {
+    path: 'filename',
+    width: '100px',
+    headerCell: {
+      render: () => `Filename`
+    },
+    bodyCell: {
+      render: item => item.filename
+    }
+  },
+  {
+    path: 'size',
+    width: '50px',
+    headerCell: {
+      render: () => `Size`
+    },
+    bodyCell: {
+      render: item => item.size
+    }
+  },
+  {
+    path: 'addedOn',
+    width: '150px',
+    headerCell: {
+      render: () => `Added on`
+    },
+    bodyCell: {
+      render: item => item.addedOn
+    }
+  }
+];
+
+export const items = [
+  {
+    reference: '1',
+    patientName: 'James Harden',
+    organ: 'Thyroid gland',
+    disease: 'Long disease name',
+    supplier: 'Clyde Drexler',
+    tags: ['annotated-by-mr'],
+    filename: 'super-high-resolution-picture-2019-2019-05-08.jpg',
+    size: '50 M',
+    addedOn: 'Apr 16, 2019'
+  },
+  {
+    reference: '2',
+    patientName: 'Stephen Curry',
+    organ: 'Medulla oblongata',
+    disease: 'Disease name',
+    supplier: 'Kareem Abdul-Jabbar',
+    tags: ['to-annotate'],
+    filename: 'an-other-pic.jpg',
+    size: '30 M',
+    addedOn: 'Apr 30, 2019'
+  }
+];

--- a/playground/src/docs/list-helpers/list-random-content.js
+++ b/playground/src/docs/list-helpers/list-random-content.js
@@ -1,0 +1,28 @@
+export function generateRandomListContent({rowCount, columnCount, width = 120}) {
+  const items = times(rowCount);
+
+  const columns = times(columnCount).map(i => ({
+    path: `col${i}`,
+    width,
+    headerCell: {render: () => `Column #${i + 1} ${generateRandomString()}`},
+    bodyCell: {
+      render: item => {
+        return `Cell ${item + 1}, ${i + 1} ${generateRandomString()}`;
+      }
+    },
+    footerCell: {render: () => `Footer #${i + 1} ${generateRandomString()}`}
+  }));
+
+  return {items, columns};
+}
+
+function generateRandomString() {
+  const letters = 'ABCD EFGH IJKL MNOP';
+  const generateRandomLengthContent = length => letters.slice(length);
+  const length = parseInt(Math.random() * letters.length, 0);
+  return generateRandomLengthContent(length);
+}
+
+function times(count) {
+  return Array.from([...Array(count)].keys()); // equivalent of Lodash `times()` function
+}

--- a/playground/src/docs/list-helpers/list-random-content.js
+++ b/playground/src/docs/list-helpers/list-random-content.js
@@ -4,13 +4,13 @@ export function generateRandomListContent({rowCount, columnCount, width = 120}) 
   const columns = times(columnCount).map(i => ({
     path: `col${i}`,
     width,
-    headerCell: {render: () => `Column #${i + 1} ${generateRandomString()}`},
+    headerCell: {content: () => `Column #${i + 1} ${generateRandomString()}`},
     bodyCell: {
-      render: item => {
+      content: item => {
         return `Cell ${item + 1}, ${i + 1} ${generateRandomString()}`;
       }
     },
-    footerCell: {render: () => `Footer #${i + 1} ${generateRandomString()}`}
+    footerCell: {content: () => `Footer #${i + 1} ${generateRandomString()}`}
   }));
 
   return {items, columns};

--- a/playground/src/docs/list-helpers/list-simple-content.js
+++ b/playground/src/docs/list-helpers/list-simple-content.js
@@ -1,47 +1,44 @@
 export const columns = [
+  // Using the `path` property to render the cell
   {
     path: 'id',
-    footerCell: {
-      render: ''
-    }
+    footerCell: ''
   },
+  // Example of column using the shorthand syntax for column content
   {
     path: 'firstName',
     width: '200px',
-    headerCell: {
-      render: () => 'First Name'
-    },
-    footerCell: {
-      render: () => 'Footer 1'
-    }
+    headerCell: 'First name',
+    bodyCell: item => item.firstName,
+    footerCell: 'Footer 1'
   },
   {
     path: 'lastName',
     width: '200px',
     headerCell: {
-      render: () => 'Last Name'
+      content: 'Last name'
     },
     bodyCell: {
-      render: item => item.lastName,
-      style: item => (item.lastName === 'Jordan' ? {fontWeight: 'bold'} : {})
+      content: item => item.lastName,
+      style: item => (item.lastName === 'Jordan' ? {fontWeight: 'bold'} : {}) // using a function
     },
     footerCell: {
-      render: () => 'Footer 2'
+      content: () => 'Footer 2'
     }
   },
   {
     path: 'team',
     headerCell: {
-      render: () => 'Team',
+      content: () => 'Team',
       tooltip: `Player's most famous team`
     },
     bodyCell: {
-      render: item => item.team,
+      content: item => item.team,
       tooltip: item => `${item.lastName} 's main team`,
-      style: {backgroundColor: '#fef9eb'}
+      style: {backgroundColor: '#fef9eb'} // using a style object instead of a function
     },
     footerCell: {
-      render: () => 'Footer 3'
+      content: () => 'Footer 3'
     }
   }
 ];

--- a/playground/src/docs/list-helpers/list-simple-content.js
+++ b/playground/src/docs/list-helpers/list-simple-content.js
@@ -33,11 +33,11 @@ export const columns = [
     path: 'team',
     headerCell: {
       render: () => 'Team',
-      title: `Player's most famous team`
+      tooltip: `Player's most famous team`
     },
     bodyCell: {
       render: item => item.team,
-      title: item => `${item.lastName} 's main team`,
+      tooltip: item => `${item.lastName} 's main team`,
       style: {backgroundColor: '#fef9eb'}
     },
     footerCell: {
@@ -81,7 +81,7 @@ export const items = [
     id: 6,
     lastName: 'Liliard',
     firstName: 'Damian',
-    team: 'Portand Trailblazers'
+    team: 'Portland Trailblazers'
   },
   {
     id: 7,

--- a/playground/src/docs/list-helpers/list-simple-content.js
+++ b/playground/src/docs/list-helpers/list-simple-content.js
@@ -1,0 +1,103 @@
+export const columns = [
+  {
+    path: 'id',
+    headerCell: {
+      render: '#'
+    },
+    bodyCell: {
+      render: item => item.id
+    },
+    footerCell: {
+      render: ''
+    }
+  },
+  {
+    path: 'firstName',
+    width: '200px',
+    // style: {maxWidth: 150},
+    headerCell: {
+      render: () => 'First Name'
+    },
+    bodyCell: {
+      render: item => item.firstName
+    },
+    footerCell: {
+      render: () => 'Footer 1'
+    }
+  },
+  {
+    path: 'lastName',
+    width: '200px',
+    // style: {maxWidth: 150},
+    headerCell: {
+      render: () => 'Last Name'
+    },
+    bodyCell: {
+      render: item => item.lastName,
+      style: item => (item.lastName === 'Jordan' ? {fontWeight: 'bold'} : {})
+    },
+    footerCell: {
+      render: () => 'Footer 2'
+    }
+  },
+  {
+    path: 'team',
+    headerCell: {
+      render: () => 'Team',
+      title: `Player's most famous team`
+    },
+    bodyCell: {
+      render: item => item.team,
+      title: item => `${item.lastName} 's main team`,
+      style: {backgroundColor: '#fef9eb'}
+    },
+    footerCell: {
+      render: () => 'Footer 3'
+    }
+  }
+];
+
+export const items = [
+  {
+    id: 1,
+    lastName: 'Bird',
+    firstName: 'Larry',
+    team: 'Boston Celtics'
+  },
+  {
+    id: 2,
+    lastName: 'Jordan',
+    firstName: 'Michael',
+    team: 'Chicago Bulls'
+  },
+  {
+    id: 3,
+    lastName: 'Duncan',
+    firstName: 'Tim',
+    team: 'San Antonio Spurs'
+  },
+  {
+    id: 4,
+    lastName: 'Bryant',
+    firstName: 'Kobe',
+    team: 'LA Lakers'
+  },
+  {
+    id: 5,
+    lastName: 'Harden',
+    firstName: 'James',
+    team: 'Houston Rockets'
+  },
+  {
+    id: 6,
+    lastName: 'Liliard',
+    firstName: 'Damian',
+    team: 'Portand Trailblazers'
+  },
+  {
+    id: 7,
+    lastName: 'Antetokounmpo',
+    firstName: 'Giannis',
+    team: 'Milwaukee Bucks'
+  }
+];

--- a/playground/src/docs/list-helpers/list-simple-content.js
+++ b/playground/src/docs/list-helpers/list-simple-content.js
@@ -1,12 +1,6 @@
 export const columns = [
   {
     path: 'id',
-    headerCell: {
-      render: '#'
-    },
-    bodyCell: {
-      render: item => item.id
-    },
     footerCell: {
       render: ''
     }
@@ -14,12 +8,8 @@ export const columns = [
   {
     path: 'firstName',
     width: '200px',
-    // style: {maxWidth: 150},
     headerCell: {
       render: () => 'First Name'
-    },
-    bodyCell: {
-      render: item => item.firstName
     },
     footerCell: {
       render: () => 'Footer 1'
@@ -28,7 +18,6 @@ export const columns = [
   {
     path: 'lastName',
     width: '200px',
-    // style: {maxWidth: 150},
     headerCell: {
       render: () => 'Last Name'
     },

--- a/playground/src/docs/list-helpers/list-sort-options.js
+++ b/playground/src/docs/list-helpers/list-sort-options.js
@@ -1,0 +1,34 @@
+import {useState} from 'react';
+
+export function useSortOptions({orderBy: initialOrderBy, orderDirection: initialOrderDirection}) {
+  const [{orderBy, orderDirection}, setSortOptions] = useState({
+    orderBy: initialOrderBy,
+    orderDirection: initialOrderDirection
+  });
+
+  const toggleOrderDirection = () => (orderDirection === 'ASC' ? 'DESC' : 'ASC');
+
+  const toggle = path => {
+    if (path === orderBy) {
+      return setSortOptions({orderBy, orderDirection: toggleOrderDirection()});
+    }
+    setSortOptions({orderBy: path, orderDirection: 'ASC'});
+  };
+
+  return {
+    orderBy,
+    orderDirection,
+    toggle
+  };
+}
+
+export function sortItems(items, {orderBy, orderDirection = 'ASC'}) {
+  const sorted = items.slice();
+
+  sorted.sort((a, b) => {
+    const difference = a[orderBy] > b[orderBy] ? 1 : -1;
+    return orderDirection === 'ASC' ? difference : -difference;
+  });
+
+  return sorted;
+}

--- a/playground/src/docs/list.mdx
+++ b/playground/src/docs/list.mdx
@@ -83,9 +83,9 @@ Building the table with `ListRoot`, composing all `List*` components
       </ListBody>
       <ListFooter>
         <ListRow>
-          <ListCell>&nbsp;</ListCell>
-          <ListCell> </ListCell>
-          <ListCell> </ListCell>
+          <ListCell>Footer 1</ListCell>
+          <ListCell>Footer 2</ListCell>
+          <ListCell>Footer 3</ListCell>
         </ListRow>
       </ListFooter>
     </ListRoot>

--- a/playground/src/docs/list.mdx
+++ b/playground/src/docs/list.mdx
@@ -10,6 +10,7 @@ import {
   ListRoot,
   ListHeader,
   ListBody,
+  ListFooter,
   ListRow,
   ListCell,
   Badge
@@ -80,6 +81,13 @@ Building the table with `ListRoot`, composing all `List*` components
           </ListRow>
         ))}
       </ListBody>
+      <ListFooter>
+        <ListRow>
+          <ListCell>&nbsp;</ListCell>
+          <ListCell> </ListCell>
+          <ListCell> </ListCell>
+        </ListRow>
+      </ListFooter>
     </ListRoot>
   </Root>
 </Playground>

--- a/playground/src/docs/list.mdx
+++ b/playground/src/docs/list.mdx
@@ -3,65 +3,224 @@ name: List
 route: /lists
 ---
 
+import {useState} from 'react';
 import {Playground, PropsTable} from 'docz';
-import {List} from '@medmain/react-ui-kit';
+import {
+  List,
+  ListRoot,
+  ListHeader,
+  ListBody,
+  ListRow,
+  ListCell,
+  Badge
+} from '@medmain/react-ui-kit';
+import {ItemSelection} from '@medmain/core';
 
 import Root from '../components/root';
+import {VerticalContainer} from '../components/vertical-container';
+import {columns, items} from './list-helpers/list-simple-content';
+import {columns as scanColumns, items as scanItems} from './list-helpers/list-long-content';
+import {generateRandomListContent} from './list-helpers/list-random-content';
+import {useSortOptions, sortItems} from './list-helpers/list-sort-options';
 
 # List component
 
+## Basic list
+
+A basic list to highlight:
+
+- Tooltips
+- Custom styles (the last column)
+- Sticky header and footer
+
+<Playground>
+  <Root>
+    <VerticalContainer height={200}>
+      <List columns={columns} items={items} onItemClick={console.log} />
+    </VerticalContainer>
+  </Root>
+</Playground>
+
+The same list wrapped in a taller container (no vertical scrolling)
+
+<Playground>
+  <Root>
+    <VerticalContainer height={400}>
+      <List columns={columns} items={items} onItemClick={console.log} />
+    </VerticalContainer>
+  </Root>
+</Playground>
+
+Empty list
+
+<Playground>
+  <Root>
+    <List columns={columns} items={[]} onItemClick={console.log} />
+  </Root>
+</Playground>
+
+Building the table with `ListRoot`, composing all `List*` components
+
+<Playground>
+  <Root>
+    <ListRoot onItemClick={console.log}>
+      <ListHeader>
+        <ListRow>
+          <ListCell>First Name</ListCell>
+          <ListCell>Last Name</ListCell>
+          <ListCell>Team</ListCell>
+        </ListRow>
+      </ListHeader>
+      <ListBody>
+        {items.map(item => (
+          <ListRow key={item.id}>
+            <ListCell>{item.firstName}</ListCell>
+            <ListCell>{item.lastName}</ListCell>
+            <ListCell>{item.team}</ListCell>
+          </ListRow>
+        ))}
+      </ListBody>
+    </ListRoot>
+  </Root>
+</Playground>
+
+### List with sort options
+
+Click on column headers to sort the rows.
+
 <Playground>
   {() => {
-    const columns = [
-      {
-        path: 'firstName',
-        headerCell: {
-          render: () => 'First Name'
-        },
-        bodyCell: {
-          render: item => item.firstName
-        }
-      },
-      {
-        path: 'lastName',
-        headerCell: {
-          render: () => 'Last Name'
-        },
-        bodyCell: {
-          render: item => item.lastName
-        }
-      },
-      {
-        path: 'team',
-        headerCell: {
-          render: () => 'Team'
-        },
-        bodyCell: {
-          render: item => item.team
-        }
-      }
-    ];
-    const items = [
-      {
-        lastName: 'Bird',
-        firstName: 'Larry',
-        team: 'Boston Celtics'
-      },
-      {
-        lastName: 'Jordan',
-        firstName: 'Michael',
-        team: 'Chicago Bulls'
-      },
-      {
-        lastName: 'Duncan',
-        firstName: 'Tim',
-        team: 'San Antonio Spurs'
-      }
-    ];
+    const {orderBy, orderDirection, toggle} = useSortOptions({orderBy: 'lastName'});
+    const sortedItems = sortItems(items, {orderBy, orderDirection});
     return (
       <Root>
-        <List columns={columns} items={items} />
+        <List
+          columns={columns}
+          items={sortedItems}
+          orderBy={orderBy}
+          orderDirection={orderDirection}
+          onHeaderClick={toggle}
+        />
       </Root>
     );
   }}
+</Playground>
+
+### List with selected items
+
+Check/uncheck boxes in the first column
+
+<Playground>
+  {() => {
+    const [selection, setSelection] = useState(new ItemSelection());
+    const {itemIds, mode} = selection
+    const selectionInfo = () => {
+      if (mode === 'all') return 'All items selected'
+      const count = itemIds && itemIds.size
+      if (count === 0) return 'No items selected'
+      return `${count} item(s) ${mode === 'pick' ? 'picked' : 'omitted'}`
+    }
+    return (
+      <Root>
+        <p>{selectionInfo()}</p>
+        <List columns={columns} items={items} selection={selection} onSelect={setSelection} onItemClick={console.log} />
+      </Root>
+    );
+
+}}
+
+</Playground>
+
+### More columns
+
+<Playground>
+  {() => {
+    const {orderBy, orderDirection, toggle} = useSortOptions({orderBy: 'addedOn'});
+    const sortedItems = sortItems(scanItems, {orderBy, orderDirection});
+    return (
+      <Root>
+        <List
+          columns={scanColumns}
+          items={sortedItems}
+          orderBy={orderBy}
+          orderDirection={orderDirection}
+          onHeaderClick={toggle}
+        />
+      </Root>
+    );
+  }}
+</Playground>
+
+Truncating the content of all cells
+
+<Playground>
+  <Root>
+    <List columns={scanColumns} items={scanItems} columnDefaults={{truncate: true}} />
+  </Root>
+</Playground>
+
+Truncating everything except the "Organ" column
+
+<Playground>
+  <Root>
+    <List
+      columns={scanColumns.map(col => (col.path === 'organ' ? {...col, truncate: false} : col))}
+      items={scanItems}
+      columnDefaults={{truncate: true}}
+    />
+  </Root>
+</Playground>
+
+Truncating only the content of the "Filename" column
+
+<Playground>
+  <Root>
+    <List
+      columns={scanColumns.map(col => (col.path === 'filename' ? {...col, truncate: true} : col))}
+      items={scanItems}
+      columnDefaults={{truncate: false}}
+    />
+  </Root>
+</Playground>
+
+## Scrollable list
+
+### Adding scrollbars
+
+Using `shrink: false` option, columns are not shrunk and the user can scroll to see the cells that don't fit the content.
+
+<Playground>
+  {() => {
+    const {items, columns} = generateRandomListContent({rowCount: 30, columnCount: 20, width: 120});
+
+    return (
+      <Root>
+        <VerticalContainer height={400}>
+          <List columns={columns} items={items} columnDefaults={{shrink: false}} />
+        </VerticalContainer>
+      </Root>
+    );
+
+}}
+
+</Playground>
+
+### Truncating cell content
+
+Using `truncate: true` option, the cell content is displayed on a single line, `...` is displayed if the content is truncated.
+
+<Playground>
+  {() => {
+    const {items, columns} = generateRandomListContent({rowCount: 30, columnCount: 20, width: 120});
+
+    return (
+      <Root>
+        <VerticalContainer height={400}>
+          <List columns={columns} items={items} columnDefaults={{shrink: false, truncate: true}} />
+        </VerticalContainer>
+      </Root>
+    );
+
+}}
+
 </Playground>

--- a/playground/src/docs/list.mdx
+++ b/playground/src/docs/list.mdx
@@ -27,7 +27,7 @@ import {useSortOptions, sortItems} from './list-helpers/list-sort-options';
 
 ## Basic list
 
-A basic list to highlight:
+A basic list to showcase:
 
 - Tooltips
 - Custom styles (the last column)


### PR DESCRIPTION
Goal: improve `List` component by adding an option to make the content horizontally scrollable.

Useful when there is a lot of content to display, this feature is needed to display correctly the _Annotation Report_ in Pidport Datastore.

Use `shrink: false` to make the table scrollable:

```jsx
<List
  columns={columns}
  items={items} 
  columnDefaults={{ shrink: false, truncate: true }} 
/>
```

Other points:

- Make the component more flexible: `render`, `style` and `tooltip` options can accept either functions or values
- If no `render` is provided for a body cell, column `path` property will be evaluated, using Lodash `get` function
- Simplify component markup, using only one `<table>` instead of 3, taking advantage of CSS `sticky` poistion, used for header and footer cells
- Rename `title` option => `tooltip`

The playground has been updated with several examples to showcase all variations, check the public URL: http://medmain-playground.surge.sh/lists