### PR TITLE
Add `<MultiInput>` component

### DIFF
--- a/package/src/form.js
+++ b/package/src/form.js
@@ -52,3 +52,21 @@ export class LabelHelp extends React.Component {
     return <small {...this.props} style={{marginLeft: '.6rem', color: t.labelColor}} />;
   }
 }
+
+@withRadiumStarter
+export class Asterisk extends React.Component {
+  static propTypes = {
+    theme: PropTypes.object.isRequired,
+    styles: PropTypes.object.isRequired
+  };
+
+  shouldComponentUpdate(_nextProps, _nextState) {
+    return false;
+  }
+
+  render() {
+    const {theme: t} = this.props;
+
+    return <span style={{color: t.errorColor}}>*</span>;
+  }
+}

--- a/package/src/input.js
+++ b/package/src/input.js
@@ -10,6 +10,7 @@ import matchSorter from 'match-sorter';
 import {withLocale} from './locale-context';
 import {withForwardedRef} from './helpers';
 import {RSInput} from './rs-input';
+import {Asterisk} from './form';
 
 @withForwardedRef
 export class Input extends React.Component {

--- a/package/src/input.js
+++ b/package/src/input.js
@@ -130,16 +130,14 @@ export class NumberInput extends React.Component {
 }
 
 @withForwardedRef
+@withLocale
 export class TextArea extends React.Component {
   static propTypes = {
     value: PropTypes.string,
     onChange: PropTypes.func.isRequired,
     required: PropTypes.bool,
-    style: PropTypes.object
-  };
-
-  static defaultProps = {
-    value: ''
+    style: PropTypes.object,
+    locale: PropTypes.object.isRequired
   };
 
   shouldComponentUpdate(nextProps, _nextState) {
@@ -151,16 +149,22 @@ export class TextArea extends React.Component {
   }
 
   handleChange = event => {
-    this.props.onChange(event.target.value);
+    const {onChange, locale} = this.props;
+
+    const value = locale.parseTextInput(event.target.value);
+    onChange(value);
   };
 
   render() {
-    const {forwardedRef, ...props} = this.props;
+    const {forwardedRef, value, locale, ...props} = this.props;
+
+    const formattedValue = locale.formatTextInput(value);
 
     return (
       <RSTextArea
         ref={forwardedRef}
         {...props}
+        value={formattedValue}
         onChange={this.handleChange}
         style={{display: 'block', width: '100%', ...this.props.style}}
       />
@@ -226,10 +230,10 @@ export class CheckboxInput extends React.Component {
 
 @withForwardedRef
 @withRadiumStarter
+@withLocale
 export class AutocompleteInput extends React.Component {
   static propTypes = {
     type: PropTypes.string,
-    forwardedRef: PropTypes.object,
     id: PropTypes.string,
     value: PropTypes.string,
     onChange: PropTypes.func.isRequired,
@@ -241,12 +245,13 @@ export class AutocompleteInput extends React.Component {
     placeholder: PropTypes.string,
     maxLength: PropTypes.number,
     style: PropTypes.object,
+    forwardedRef: PropTypes.object,
+    locale: PropTypes.object.isRequired,
     theme: PropTypes.object.isRequired,
     styles: PropTypes.object.isRequired
   };
 
   static defaultProps = {
-    value: '',
     items: []
   };
 
@@ -285,8 +290,11 @@ export class AutocompleteInput extends React.Component {
   }
 
   handleChange = value => {
-    if (value !== this.props.value) {
-      this.props.onChange(value);
+    const {value: previousValue, locale} = this.props;
+
+    const nextValue = locale.parseTextInput(value);
+    if (nextValue !== previousValue) {
+      this.props.onChange(nextValue);
     }
   };
 
@@ -303,6 +311,7 @@ export class AutocompleteInput extends React.Component {
       placeholder,
       maxLength,
       style,
+      locale,
       theme: t,
       styles: s
     } = this.props;
@@ -311,12 +320,14 @@ export class AutocompleteInput extends React.Component {
     let filteredItems = items.filter(item => item !== value);
     filteredItems = matchSorter(filteredItems, value);
 
+    const formattedValue = locale.formatTextInput(value);
+
     return (
       <Downshift
         onChange={this.handleChange}
-        inputValue={value}
+        inputValue={formattedValue}
         onInputValueChange={this.handleChange}
-        selectedItem={value}
+        selectedItem={formattedValue}
       >
         {({getInputProps, getItemProps, isOpen, highlightedIndex}) => (
           <div style={{position: 'relative'}}>

--- a/package/src/input.js
+++ b/package/src/input.js
@@ -376,3 +376,105 @@ export class Asterisk extends React.Component {
     return <span style={{color: t.errorColor}}>*</span>;
   }
 }
+
+@withForwardedRef
+export class MultiInput extends React.Component {
+  static propTypes = {
+    values: PropTypes.array.isRequired,
+    onChange: PropTypes.func.isRequired,
+    required: PropTypes.bool,
+    forwardedRef: PropTypes.object,
+    spacing: PropTypes.string,
+    layout: PropTypes.oneOf(['vertical', 'horizontal']),
+    style: PropTypes.object,
+    children: PropTypes.func.isRequired
+  };
+
+  static defaultProps = {
+    layout: 'horizontal',
+    spacing: '1rem'
+  };
+
+  onUpdate(value, index) {
+    const {onChange} = this.props;
+
+    const currentValues = this.getRenderedValues();
+    const updatedValues = currentValues.map((currentValue, i) => {
+      return index === i ? value : currentValue;
+    });
+
+    return onChange(updatedValues);
+  }
+
+  getRenderedValues = () => {
+    const {values} = this.props;
+
+    const hasExtraEmptyInput = values[values.length - 1] === '';
+
+    return hasExtraEmptyInput ? values : [...values, ''];
+  };
+
+  onRemove = index => {
+    const {values, onChange} = this.props;
+
+    const newValues = values.filter((_, i) => i !== index);
+
+    return onChange(newValues);
+  };
+
+  isEmpty = () => {
+    const {values} = this.props;
+
+    return values.length === 0 || values.every(value => value === '');
+  };
+
+  render() {
+    const {forwardedRef, required, layout, spacing, style, children} = this.props;
+
+    const isMultiInputEmpty = this.isEmpty();
+
+    const containerStyles = {
+      display: 'flex',
+      flexWrap: 'wrap',
+      marginTop: `-${spacing}`,
+      marginLeft: `-${spacing}`
+    };
+    const cellStyles = {paddingTop: spacing, paddingLeft: spacing};
+    const renderedValues = this.getRenderedValues();
+
+    return (
+      <div
+        style={{
+          ...(layout === 'horizontal' ? containerStyles : undefined),
+          ...style
+        }}
+      >
+        {renderedValues.map((value, index) => {
+          const isFirst = index === 0;
+          const isLast = index === renderedValues.length - 1;
+
+          return (
+            <div key={index} style={{...(layout === 'horizontal' ? cellStyles : undefined)}}>
+              {children({
+                forwardedRef: isFirst ? forwardedRef : undefined,
+                value,
+                onChange: value => this.onUpdate(value, index),
+                onRemove: isLast ? undefined : () => this.onRemove(index),
+                required: required && isMultiInputEmpty && isFirst,
+                index,
+                isFirst,
+                isLast
+              })}
+            </div>
+          );
+        })}
+      </div>
+    );
+  }
+}
+
+// function updateArrayItemAtIndex(array, itemNewValue, itemIndex) {
+//   return array.map((currentValue, index) => {
+//     return index === itemIndex ? itemNewValue : currentValue;
+//   });
+// }

--- a/package/src/input.js
+++ b/package/src/input.js
@@ -3,7 +3,7 @@ import PropTypes from 'prop-types';
 import {withRadiumStarter, TextArea as RSTextArea} from 'radium-starter';
 import isEqual from 'lodash/isEqual';
 import omit from 'lodash/omit';
-import isNil from 'lodash/isNil';
+import isEmpty from 'lodash/isEmpty';
 import Downshift from 'downshift';
 import matchSorter from 'match-sorter';
 
@@ -398,7 +398,7 @@ export class MultiInput extends React.Component {
     const {values} = this.props;
 
     const lastValue = values[values.length - 1];
-    const hasExtraEmptyInput = values.length && isNil(lastValue);
+    const hasExtraEmptyInput = values.length && isEmpty(lastValue);
 
     return hasExtraEmptyInput ? values : [...values, undefined];
   };
@@ -414,7 +414,7 @@ export class MultiInput extends React.Component {
   isEmpty = () => {
     const {values} = this.props;
 
-    return values.every(value => isNil(value) || value === '');
+    return values.every(value => isEmpty(value));
   };
 
   render() {
@@ -429,9 +429,9 @@ export class MultiInput extends React.Component {
         style={{
           display: 'flex',
           flexWrap: layout === 'horizontal' ? 'wrap' : undefined,
+          flexDirection: layout === 'horizontal' ? 'row' : 'column',
           marginTop: `-${spacing}`,
           marginLeft: layout === 'horizontal' ? `-${spacing}` : undefined,
-          flexDirection: layout === 'horizontal' ? 'row' : 'column',
           ...style
         }}
       >

--- a/package/src/input.js
+++ b/package/src/input.js
@@ -197,7 +197,14 @@ export class CheckboxInput extends React.Component {
     const {label, value, forwardedRef, required, style} = this.props;
 
     return (
-      <label style={{display: 'flex', alignItems: 'center', ...style}} htmlFor={this.id}>
+      <div
+        style={{
+          display: 'flex',
+          alignItems: 'center',
+          ...style
+        }}
+        htmlFor={this.id}
+      >
         <RSInput
           ref={forwardedRef}
           {...omit(this.props, ['value'])}
@@ -207,12 +214,12 @@ export class CheckboxInput extends React.Component {
           onChange={this.handleChange}
         />
         {label && (
-          <span style={{paddingLeft: '0.5rem', verticalAlign: 'middle'}}>
+          <label style={{paddingLeft: '0', verticalAlign: 'middle'}} htmlFor={this.id}>
             {label}
             {required && <Asterisk />}
-          </span>
+          </label>
         )}
-      </label>
+      </div>
     );
   }
 }

--- a/package/src/select.js
+++ b/package/src/select.js
@@ -107,10 +107,8 @@ export class RadioSelect extends React.Component {
       const id = this.name + '-' + option.value;
 
       return (
-        <label
-          htmlFor={id}
+        <div
           key={id}
-          ref={index === 0 ? forwardedRef : undefined} // to be able to set focus on the 1st radio button
           style={{
             display: layout === 'vertical' ? 'flex' : 'inline-flex',
             alignItems: 'center',
@@ -118,6 +116,7 @@ export class RadioSelect extends React.Component {
           }}
         >
           <RSInput
+            ref={index === 0 ? forwardedRef : undefined} // to be able to set focus on the 1st radio button
             type="radio"
             id={id}
             name={this.name}
@@ -126,8 +125,10 @@ export class RadioSelect extends React.Component {
             onChange={this.handleChange}
             required={required}
           />
-          <span style={{paddingLeft: '0.5rem'}}>{option.label}</span>
-        </label>
+          <label htmlFor={id} style={{paddingLeft: '0'}}>
+            {option.label}
+          </label>
+        </div>
       );
     });
 

--- a/playground/doczrc.js
+++ b/playground/doczrc.js
@@ -2,6 +2,7 @@ export default {
   title: 'Medmain React UI Kit',
   description:
     'A playground to visualize and test Medmain React components shared in `@medmain/react-ui-kit` package',
+  menu: ['Home'],
   codeSandbox: false,
   propsParser: false, // propsTable component only works with default imports
   themeConfig: {

--- a/playground/package.json
+++ b/playground/package.json
@@ -8,13 +8,14 @@
     "deploy": "cp .docz/dist/index.html .docz/dist/200.html && surge --project .docz/dist/ --domain medmain-playground.surge.sh"
   },
   "dependencies": {
-    "@babel/plugin-proposal-class-properties": "^7.3.3",
-    "@babel/plugin-proposal-decorators": "^7.3.0",
+    "@babel/plugin-proposal-class-properties": "^7.4.4",
+    "@babel/plugin-proposal-decorators": "^7.4.4",
+    "@babel/polyfill": "^7.4.4",
     "@medmain/base-frontend": "^0.1.66",
-    "@medmain/core": "^0.2.1",
+    "@medmain/core": "^0.2.0",
     "@medmain/react-ui-kit": "^0.2.0",
-    "docz": "^0.13.7",
-    "docz-theme-default": "^0.13.7",
-    "webpack": "4.28.4"
+    "docz": "^1.2.0",
+    "docz-theme-default": "1.2.0",
+    "react": "^16.8.6"
   }
 }

--- a/playground/src/components/checking-refs.js
+++ b/playground/src/components/checking-refs.js
@@ -56,19 +56,20 @@ export class CheckingRefs extends React.Component {
           onChange={this.handleChange}
         />
         <hr />
-        <label style={{display: 'flex', alignItems: 'center'}}>
+        <div style={{display: 'flex', alignItems: 'center'}}>
           <RSInput
+            id="accept"
             name="accept"
             type="checkbox"
             checked={values.accept === true}
             ref={this.inputRefs[2]}
             onChange={this.handleChange}
           />
-          <div style={{marginLeft: '0.5rem'}}>I accept</div>
-        </label>
+          <label htmlFor="accept">I accept</label>
+        </div>
         <hr />
-        <div style={{display: 'flex', alignItems: 'center'}}>
-          <label>
+        <div style={{}}>
+          <div style={{display: 'flex', alignItems: 'center'}}>
             <RSInput
               name="choice"
               type="radio"
@@ -77,9 +78,9 @@ export class CheckingRefs extends React.Component {
               ref={this.inputRefs[3]}
               onChange={this.handleChange}
             />
-            <span>Celtics</span>
-          </label>
-          <label>
+            <label>Celtics</label>
+          </div>
+          <div style={{display: 'flex', alignItems: 'center'}}>
             <RSInput
               name="choice"
               type="radio"
@@ -87,8 +88,8 @@ export class CheckingRefs extends React.Component {
               checked={values.choice === 'Lakers'}
               onChange={this.handleChange}
             />
-            <span>Lakers</span>
-          </label>
+            <label>Lakers</label>
+          </div>
         </div>
         <hr />
         <p>Push the buttons to set the focus on...</p>

--- a/playground/src/components/root.js
+++ b/playground/src/components/root.js
@@ -1,3 +1,5 @@
+import '@babel/polyfill'; // fix build error `regeneratorRuntime is not defined`
+
 import React from 'react';
 import PropTypes from 'prop-types';
 import {createBaseApp} from '@medmain/base-frontend';

--- a/playground/src/docs/button.mdx
+++ b/playground/src/docs/button.mdx
@@ -3,7 +3,7 @@ name: Button
 route: /buttons
 ---
 
-import {Playground, PropsTable} from 'docz';
+import {Playground} from 'docz';
 import {
   Button,
   RoundButton,

--- a/playground/src/docs/dropdown-menu.mdx
+++ b/playground/src/docs/dropdown-menu.mdx
@@ -3,7 +3,7 @@ name: Dropdown menu
 route: /dropdown-menu
 ---
 
-import {Playground, PropsTable} from 'docz';
+import {Playground} from 'docz';
 import {DropdownMenu, DropdownItem, Col, Row} from '@medmain/react-ui-kit';
 
 import Root from '../components/root';

--- a/playground/src/docs/form.mdx
+++ b/playground/src/docs/form.mdx
@@ -3,10 +3,8 @@ name: Form
 route: /forms
 ---
 
-import {Playground, PropsTable} from 'docz';
-
+import {Playground} from 'docz';
 import {
-  Asterisk,
   Button,
   CheckboxInput,
   DateInput,

--- a/playground/src/docs/home.mdx
+++ b/playground/src/docs/home.mdx
@@ -1,6 +1,6 @@
 ---
 route: /
-order: 1
+name: Home
 ---
 
 # React UI Kit Playground

--- a/playground/src/docs/input.mdx
+++ b/playground/src/docs/input.mdx
@@ -4,7 +4,6 @@ route: /inputs
 ---
 
 import {Playground} from 'docz';
-
 import {
   RSInput,
   Input,

--- a/playground/src/docs/input.mdx
+++ b/playground/src/docs/input.mdx
@@ -53,13 +53,20 @@ Instead of a `value` prop, checkboxes expect a `checked` property (boolean).
 
 <Playground>
   <Root>
-    <RSInput type="checkbox" onChange={console.log} />
-    <span> </span>
-    <RSInput type="checkbox" checked onChange={console.log} />
-    <span> </span>
-    <RSInput type="checkbox" disabled onChange={console.log} />
-    <span> </span>
-    <RSInput type="checkbox" disabled checked onChange={console.log} />
+    <FormContainer initialValues={{first: false, second: true}}>
+      {({values, handleChangeEvent}) =>
+      <>
+        <RSInput type="checkbox" checked={values.first} name="first" onChange={handleChangeEvent} />
+        <span> </span>
+        <RSInput type="checkbox" checked={values.second} name="second" onChange={handleChangeEvent} />
+        <span> </span>
+        <RSInput type="checkbox" disabled onChange={console.log} />
+        <span> </span>
+        <RSInput type="checkbox" disabled checked onChange={console.log} />
+      </>
+      }
+    </FormContainer>
+
   </Root>
 </Playground>
 
@@ -73,77 +80,29 @@ Radio buttons expect both a `value` and a `checked` props.
 
 <Playground>
   <Root>
-    <div style={{display: 'flex', alignItems: 'center'}}>
-      <RSInput type="radio" value={'1'} onChange={console.log} />
-      <span> </span>
-      <RSInput type="radio" value={'1'} checked onChange={console.log} />
-      <span> </span>
-      <RSInput type="radio" value={'1'} disabled onChange={console.log} />
-      <span> </span>
-      <RSInput type="radio" value={'1'} disabled checked onChange={console.log} />
-    </div>
-  </Root>
-</Playground>
-
-### Adding labels and event handling
-
-<Playground>
-  <Root>
-    <FormContainer
-      initialValues={{
-        special: false,
-        available: true
-      }}
-    >
+    <FormContainer initialValues={{level: '1'}}>
       {({values, handleChangeEvent}) => (
         <>
-          {values.special}
-          <label htmlFor="special">
-            <RSInput
-              type="checkbox"
-              id="special"
-              name="special"
-              checked={values.special}
-              onChange={handleChangeEvent}
-            />
-            Special
-          </label>
+          <RSInput
+            type="radio"
+            value="1"
+            checked={values.level === '1'}
+            name="level"
+            onChange={handleChangeEvent}
+          />
           <span> </span>
-          <label htmlFor="available">
-            <RSInput
-              type="checkbox"
-              id="available"
-              name="available"
-              checked={values.available}
-              onChange={handleChangeEvent}
-            />
-            Available
-          </label>
+          <RSInput
+            type="radio"
+            value="2"
+            checked={values.level === '2'}
+            name="level"
+            onChange={handleChangeEvent}
+          />
+          <span> </span>
+          <RSInput type="radio" name="choice2" disabled onChange={console.log} />
+          <span> </span>
+          <RSInput type="radio" name="choice2" disabled checked onChange={console.log} />
         </>
-      )}
-    </FormContainer>
-  </Root>
-</Playground>
-
-<Playground>
-  <Root>
-    <FormContainer initialValues={{team: '2'}}>
-      {({values: {team}, handleChangeEvent}) => (
-        <div style={{display: 'flex', alignItems: 'center'}}>
-          {items.slice(0, 3).map(({id, team: text}) => (
-            <label key={id} htmlFor={id} style={{display: 'inline-flex', marginRight: '1rem'}}>
-              <RSInput
-                type="radio"
-                name="team"
-                value={id}
-                id={id}
-                checked={team === id}
-                onChange={handleChangeEvent}
-              />
-              <span>{text}</span>
-            </label>
-          ))}
-        </div>
       )}
     </FormContainer>
   </Root>
@@ -230,7 +189,7 @@ the callback function is called passing the **value** of the field instead of an
   <Root>
     <FormContainer initialValues={{accept: false}}>
       {({values, onChange}) => {
-        const ref = React.createRef();
+        const ref = React.useRef(null);
         return (
           <Form onSubmit={console.log}>
             <CheckboxInput
@@ -238,6 +197,7 @@ the callback function is called passing the **value** of the field instead of an
               label={'I accept'}
               value={values.accept}
               onChange={onChange('accept')}
+              required
             />
             <br />
             <CheckboxInput

--- a/playground/src/docs/list.mdx
+++ b/playground/src/docs/list.mdx
@@ -130,8 +130,10 @@ Check/uncheck boxes in the first column
     }
     return (
       <Root>
-        <p>{selectionInfo()}</p>
-        <List columns={columns} items={items} selection={selection} onSelect={setSelection} onItemClick={console.log} />
+        <VerticalContainer height={300}>
+          <p>{selectionInfo()}</p>
+          <List columns={columns} items={items} selection={selection} onSelect={setSelection} onItemClick={console.log} />
+        </VerticalContainer>
       </Root>
     );
 

--- a/playground/src/docs/list.mdx
+++ b/playground/src/docs/list.mdx
@@ -4,7 +4,7 @@ route: /lists
 ---
 
 import {useState} from 'react';
-import {Playground, PropsTable} from 'docz';
+import {Playground} from 'docz';
 import {
   List,
   ListRoot,

--- a/playground/src/docs/modal.mdx
+++ b/playground/src/docs/modal.mdx
@@ -3,7 +3,7 @@ name: Modal
 route: /modal
 ---
 
-import {Playground, PropsTable} from 'docz';
+import {Playground} from 'docz';
 import {Button, Modal} from '@medmain/react-ui-kit';
 
 import {ModalDemo} from '../components/modal-demo';

--- a/playground/src/docs/multi-input.mdx
+++ b/playground/src/docs/multi-input.mdx
@@ -23,7 +23,7 @@ import {items} from './list-helpers/list-simple-content';
 # MultiInput
 
 A flexible component to update any **array** of values.
-`<MultipleInput>` renders N occurrences of the same `<Input*>` component provided by the user, through a `render props` pattern.
+`<MultiInput>` renders N occurrences of the same `<Input*>` component provided by the user, through a `render props` pattern.
 
 Editing the last input automatically add a new field. It's up to the user to remove empty values when the form is validated.
 

--- a/playground/src/docs/multi-input.mdx
+++ b/playground/src/docs/multi-input.mdx
@@ -1,0 +1,184 @@
+---
+name: Multi Input
+route: /multi-inputs
+---
+
+import {Playground} from 'docz';
+import {
+  Input,
+  TextInput,
+  NumberInput,
+  AutocompleteInput,
+  Form,
+  Button,
+  Select,
+  TextArea,
+  MultiInput
+} from '@medmain/react-ui-kit';
+
+import {FormContainer} from '../components/form-container';
+import Root from '../components/root';
+import {items} from './list-helpers/list-simple-content';
+
+# MultiInput
+
+A flexible component to update any **array** of values.
+`<MultipleInput>` renders N occurrences of the same `<Input*>` component provided by the user, through a `render props` pattern.
+
+Editing the last input automatically add a new field. It's up to the user to remove empty values when the form is validated.
+
+## With multiple Input fields
+
+With a default value:
+
+<Playground>
+  <Root>
+    <FormContainer initialValues={{players: ['Larry', 'Michael', 'Clyde']}}>
+      {({values, onChange}) => (
+        <MultiInput values={values.players} onChange={onChange('players')}>
+          {({value, onChange, required}) => (
+            <Input value={value} onChange={onChange} style={{width: '120px', display: 'inline'}} />
+          )}
+        </MultiInput>
+      )}
+    </FormContainer>
+  </Root>
+</Playground>
+
+Passing an empty array as the default value:
+
+<Playground>
+  <Root>
+    <FormContainer initialValues={{players: []}}>
+      {({values, onChange}) => {
+        const ref = React.createRef();
+        return (
+          <Form onSubmit={() => console.log(values)}>
+            <MultiInput ref={ref} values={values.players} onChange={onChange('players')} required>
+              {({value, onChange, forwardedRef, required}) => (
+                <Input
+                  ref={forwardedRef}
+                  value={value}
+                  onChange={onChange}
+                  style={{width: '120px', display: 'inline'}}
+                  required={required}
+                />
+              )}
+            </MultiInput>
+            <hr />
+            <Button rsPrimary type="submit">
+              SAVE
+            </Button>{' '}
+            <Button onClick={() => ref.current.focus()}>Set focus</Button>
+          </Form>
+        );
+      }}
+    </FormContainer>
+  </Root>
+</Playground>
+
+## With Select
+
+<Playground>
+  <Root>
+    <FormContainer initialValues={{teams: []}}>
+      {({values, onChange}) => (
+        <Form onSubmit={() => console.log(values)}>
+          <MultiInput values={values.teams} onChange={onChange('teams')} required>
+            {({value, onChange, required}) => (
+              <Select
+                type="select"
+                value={value}
+                options={items.map(({id, team}) => ({value: id, label: team}))}
+                onChange={onChange}
+                required={required}
+                hasEmptyOption
+                style={{width: '150px', display: 'inline'}}
+              />
+            )}
+          </MultiInput>
+          <hr />
+          <Button rsPrimary type="submit">
+            SAVE
+          </Button>
+        </Form>
+      )}
+    </FormContainer>
+  </Root>
+</Playground>
+
+## With AutocompleteInput
+
+Increasing the spacing between the inputs with `spacing="2rem"`
+
+<Playground>
+  <Root>
+    <FormContainer initialValues={{cities: []}}>
+      {({values, onChange}) => {
+        const cities = ['Boston', 'Chicago', 'New York', 'Los Angeles', 'San Antonio'];
+        return (
+          <Form onSubmit={() => console.log(values)}>
+            <MultiInput
+              values={values.cities}
+              onChange={onChange('cities')}
+              required
+              spacing="2rem"
+            >
+              {({value, onChange, required}) => (
+                <AutocompleteInput
+                  items={cities}
+                  value={value}
+                  onChange={onChange}
+                  required={required}
+                />
+              )}
+            </MultiInput>
+            <hr />
+            <Button rsPrimary type="submit">
+              SAVE
+            </Button>
+          </Form>
+        );
+      }}
+    </FormContainer>
+  </Root>
+</Playground>
+
+## With TextArea
+
+Changing the default layout using `layout="vertical"` and adding a button to remove the item.
+
+<Playground>
+  <Root>
+    <FormContainer initialValues={{comments: []}}>
+      {({values, onChange}) => {
+        return (
+          <Form onSubmit={() => console.log(values)}>
+            <MultiInput
+              values={values.comments}
+              onChange={onChange('comments')}
+              required
+              layout={'vertical'}
+            >
+              {({value, index, onChange, onRemove, required}) => (
+                <div style={{marginBottom: '1rem'}}>
+                  <p>This is the comment number {index + 1}</p>
+                  <TextArea value={value} onChange={onChange} required={required} />
+                  {onRemove && (
+                    <Button rsSmall onClick={onRemove}>
+                      REMOVE
+                    </Button>
+                  )}
+                </div>
+              )}
+            </MultiInput>
+            <hr />
+            <Button rsPrimary type="submit">
+              SAVE
+            </Button>
+          </Form>
+        );
+      }}
+    </FormContainer>
+  </Root>
+</Playground>

--- a/playground/src/docs/multi-input.mdx
+++ b/playground/src/docs/multi-input.mdx
@@ -5,7 +5,6 @@ route: /multi-inputs
 
 import {Playground} from 'docz';
 import {
-  Input,
   TextInput,
   NumberInput,
   AutocompleteInput,
@@ -13,6 +12,7 @@ import {
   Button,
   Select,
   TextArea,
+  DateInput,
   MultiInput
 } from '@medmain/react-ui-kit';
 
@@ -27,7 +27,7 @@ A flexible component to update any **array** of values.
 
 Editing the last input automatically add a new field. It's up to the user to remove empty values when the form is validated.
 
-## With multiple Input fields
+## With TextInput
 
 With a default value:
 
@@ -37,7 +37,11 @@ With a default value:
       {({values, onChange}) => (
         <MultiInput values={values.players} onChange={onChange('players')}>
           {({value, onChange, required}) => (
-            <Input value={value} onChange={onChange} style={{width: '120px', display: 'inline'}} />
+            <TextInput
+              value={value}
+              onChange={onChange}
+              style={{width: '120px', display: 'inline'}}
+            />
           )}
         </MultiInput>
       )}
@@ -51,19 +55,21 @@ Passing an empty array as the default value:
   <Root>
     <FormContainer initialValues={{players: []}}>
       {({values, onChange}) => {
-        const ref = React.createRef();
+        const ref = React.useRef(null);
         return (
           <Form onSubmit={() => console.log(values)}>
             <MultiInput ref={ref} values={values.players} onChange={onChange('players')} required>
-              {({value, onChange, forwardedRef, required}) => (
-                <Input
-                  ref={forwardedRef}
-                  value={value}
-                  onChange={onChange}
-                  style={{width: '120px', display: 'inline'}}
-                  required={required}
-                />
-              )}
+              {({value, onChange, forwardedRef, required}) => {
+                return (
+                  <TextInput
+                    ref={forwardedRef}
+                    value={value}
+                    onChange={onChange}
+                    style={{width: '120px', display: 'inline'}}
+                    required={required}
+                  />
+                );
+              }}
             </MultiInput>
             <hr />
             <Button rsPrimary type="submit">
@@ -73,6 +79,60 @@ Passing an empty array as the default value:
           </Form>
         );
       }}
+    </FormContainer>
+  </Root>
+</Playground>
+
+## With NumberInput
+
+<Playground>
+  <Root>
+    <FormContainer initialValues={{numbers: [33, 23]}}>
+      {({values, onChange}) => (
+        <Form onSubmit={() => console.log(values)}>
+          <MultiInput values={values.numbers} onChange={onChange('numbers')} required>
+            {({value, onChange, required}) => (
+              <NumberInput
+                value={value}
+                onChange={onChange}
+                style={{width: '120px', display: 'inline'}}
+                required={required}
+              />
+            )}
+          </MultiInput>
+          <hr />
+          <Button rsPrimary type="submit">
+            SAVE
+          </Button>
+        </Form>
+      )}
+    </FormContainer>
+  </Root>
+</Playground>
+
+## With DateInput
+
+<Playground>
+  <Root>
+    <FormContainer initialValues={{dates: [new Date('2019-05-28T07:44:56.873Z')]}}>
+      {({values, onChange}) => (
+        <Form onSubmit={() => console.log(values)}>
+          <MultiInput values={values.dates} onChange={onChange('dates')} required>
+            {({value, onChange, required}) => (
+              <DateInput value={value} onChange={onChange} required={required} />
+            )}
+          </MultiInput>
+          <br />
+          <br />
+          <br />
+          <br />
+          <br />
+          <hr />
+          <Button rsPrimary type="submit">
+            SAVE
+          </Button>{' '}
+        </Form>
+      )}
     </FormContainer>
   </Root>
 </Playground>
@@ -160,16 +220,16 @@ Changing the default layout using `layout="vertical"` and adding a button to rem
               required
               layout={'vertical'}
             >
-              {({value, index, onChange, onRemove, required}) => (
-                <div style={{marginBottom: '1rem'}}>
+              {({value, index, onChange, onClear, required}) => (
+                <>
                   <p>This is the comment number {index + 1}</p>
                   <TextArea value={value} onChange={onChange} required={required} />
-                  {onRemove && (
-                    <Button rsSmall onClick={onRemove}>
+                  {onClear && (
+                    <Button rsSmall onClick={onClear}>
                       REMOVE
                     </Button>
                   )}
-                </div>
+                </>
               )}
             </MultiInput>
             <hr />

--- a/playground/src/docs/multi-input.mdx
+++ b/playground/src/docs/multi-input.mdx
@@ -36,13 +36,7 @@ With a default value:
     <FormContainer initialValues={{players: ['Larry', 'Michael', 'Clyde']}}>
       {({values, onChange}) => (
         <MultiInput values={values.players} onChange={onChange('players')}>
-          {({value, onChange, required}) => (
-            <TextInput
-              value={value}
-              onChange={onChange}
-              style={{width: '120px', display: 'inline'}}
-            />
-          )}
+          {({value, onChange, required}) => <TextInput value={value} onChange={onChange} />}
         </MultiInput>
       )}
     </FormContainer>
@@ -65,7 +59,6 @@ Passing an empty array as the default value:
                     ref={forwardedRef}
                     value={value}
                     onChange={onChange}
-                    style={{width: '120px', display: 'inline'}}
                     required={required}
                   />
                 );
@@ -92,12 +85,7 @@ Passing an empty array as the default value:
         <Form onSubmit={() => console.log(values)}>
           <MultiInput values={values.numbers} onChange={onChange('numbers')} required>
             {({value, onChange, required}) => (
-              <NumberInput
-                value={value}
-                onChange={onChange}
-                style={{width: '120px', display: 'inline'}}
-                required={required}
-              />
+              <NumberInput value={value} onChange={onChange} required={required} />
             )}
           </MultiInput>
           <hr />
@@ -153,7 +141,6 @@ Passing an empty array as the default value:
                 onChange={onChange}
                 required={required}
                 hasEmptyOption
-                style={{width: '150px', display: 'inline'}}
               />
             )}
           </MultiInput>

--- a/playground/src/docs/row.mdx
+++ b/playground/src/docs/row.mdx
@@ -3,7 +3,7 @@ name: Row and Col
 route: /rows
 ---
 
-import {Playground, PropsTable} from 'docz';
+import {Playground} from 'docz';
 import {Row, Col} from '@medmain/react-ui-kit';
 
 import Root from '../components/root';

--- a/playground/src/docs/spinner.mdx
+++ b/playground/src/docs/spinner.mdx
@@ -3,7 +3,7 @@ name: Spinner
 route: /spinner
 ---
 
-import {Playground, PropsTable} from 'docz';
+import {Playground} from 'docz';
 import {Spinner} from '@medmain/react-ui-kit';
 
 import Root from '../components/root';

--- a/playground/src/docs/tabs.mdx
+++ b/playground/src/docs/tabs.mdx
@@ -3,7 +3,7 @@ name: Tabs
 route: /tabs
 ---
 
-import {Playground, PropsTable} from 'docz';
+import {Playground} from 'docz';
 import {useState} from 'react';
 import {Tabs, Tab} from '@medmain/react-ui-kit';
 

--- a/playground/src/docs/typography.mdx
+++ b/playground/src/docs/typography.mdx
@@ -3,8 +3,7 @@ name: Typography
 route: /typography
 ---
 
-import {Playground, PropsTable} from 'docz';
-import {RadiumStarterRoot} from 'radium-starter';
+import {Playground} from 'docz';
 import {Heading1, Heading2, Heading3, Badge} from '@medmain/react-ui-kit';
 
 import Root from '../components/root';


### PR DESCRIPTION
Goal: add a flexible component `<MultipleInput> to update any **array** of values. 

`<MultiInput>` renders N occurrences of the same `<Input*>` component provided by the user, through a render props pattern.

Editing the last input automatically add a new field. It's up to the user to remove empty values when the form is validated.

Check the online demo: https://medmain-playground.surge.sh/multi-inputs