### PR TITLE
Use JavaScript to set `<FullHeight>` height

### DIFF
--- a/package/src/full-height.js
+++ b/package/src/full-height.js
@@ -40,15 +40,3 @@ export class FullHeight extends React.Component {
     );
   }
 }
-
-// function isIOSDevice() {
-//   if (typeof navigator !== 'object') {
-//     return false;
-//   }
-//   const userAgent = navigator.userAgent;
-//   if (typeof userAgent !== 'string') {
-//     return false;
-//   }
-
-//   return ['iPad', 'iPhone'].some(device => userAgent.includes(device));
-// }

--- a/package/src/full-height.js
+++ b/package/src/full-height.js
@@ -1,6 +1,8 @@
 import React from 'react';
 import PropTypes from 'prop-types';
 
+import {WindowSize} from './window-size';
+
 export class FullHeight extends React.Component {
   static propTypes = {
     growable: PropTypes.bool,
@@ -17,20 +19,36 @@ export class FullHeight extends React.Component {
 
     // Use IE11 fix: https://codepen.io/chriswrightdesign/pen/emQNGZ/
     return (
-      <div style={{display: 'flex'}}>
-        <div
-          style={{
-            flexGrow: 1,
-            display: 'flex',
-            flexDirection: 'column',
-            width: '100%',
-            [growable ? 'minHeight' : 'height']: '100vh',
-            ...style
-          }}
-        >
-          {children}
-        </div>
-      </div>
+      <WindowSize>
+        {({height}) => (
+          <div style={{display: 'flex'}}>
+            <div
+              style={{
+                flexGrow: 1,
+                display: 'flex',
+                flexDirection: 'column',
+                width: '100%',
+                [growable ? 'minHeight' : 'height']: height,
+                ...style
+              }}
+            >
+              {children}
+            </div>
+          </div>
+        )}
+      </WindowSize>
     );
   }
 }
+
+// function isIOSDevice() {
+//   if (typeof navigator !== 'object') {
+//     return false;
+//   }
+//   const userAgent = navigator.userAgent;
+//   if (typeof userAgent !== 'string') {
+//     return false;
+//   }
+
+//   return ['iPad', 'iPhone'].some(device => userAgent.includes(device));
+// }

--- a/package/src/full-height.js
+++ b/package/src/full-height.js
@@ -17,23 +17,19 @@ export class FullHeight extends React.Component {
   render() {
     const {growable, style, children} = this.props;
 
-    // Use IE11 fix: https://codepen.io/chriswrightdesign/pen/emQNGZ/
     return (
       <WindowSize>
         {({height}) => (
-          <div style={{display: 'flex'}}>
-            <div
-              style={{
-                flexGrow: 1,
-                display: 'flex',
-                flexDirection: 'column',
-                width: '100%',
-                [growable ? 'minHeight' : 'height']: height,
-                ...style
-              }}
-            >
-              {children}
-            </div>
+          <div
+            style={{
+              display: 'flex',
+              flexDirection: 'column',
+              width: '100%',
+              [growable ? 'minHeight' : 'height']: height,
+              ...style
+            }}
+          >
+            {children}
           </div>
         )}
       </WindowSize>

--- a/package/src/window-size.js
+++ b/package/src/window-size.js
@@ -1,0 +1,42 @@
+import React from 'react';
+import PropTypes from 'prop-types';
+import throttle from 'lodash/throttle';
+
+export class WindowSize extends React.Component {
+  static propTypes = {
+    throttleMs: PropTypes.number,
+    children: PropTypes.func.isRequired
+  };
+
+  static defaultProps = {
+    throttleMs: 200
+  };
+
+  state = this.getWindowSize();
+
+  getWindowSize() {
+    const width = window.innerWidth;
+    const height = window.innerHeight;
+
+    return {width, height};
+  }
+
+  componentDidMount() {
+    window.addEventListener('resize', this.handleResize);
+  }
+
+  componentWillUnmount() {
+    window.removeEventListener('resize', this.handleResize);
+  }
+
+  setWindowSize = () => {
+    const size = this.getWindowSize();
+    this.setState(size);
+  };
+
+  handleResize = throttle(this.setWindowSize, this.props.throttleMs);
+
+  render() {
+    return this.props.children({...this.state});
+  }
+}

--- a/package/src/window-size.js
+++ b/package/src/window-size.js
@@ -4,22 +4,15 @@ import throttle from 'lodash/throttle';
 
 export class WindowSize extends React.Component {
   static propTypes = {
-    throttleMs: PropTypes.number,
+    wait: PropTypes.number,
     children: PropTypes.func.isRequired
   };
 
   static defaultProps = {
-    throttleMs: 200
+    wait: 200
   };
 
   state = this.getWindowSize();
-
-  getWindowSize() {
-    const width = window.innerWidth;
-    const height = window.innerHeight;
-
-    return {width, height};
-  }
 
   componentDidMount() {
     window.addEventListener('resize', this.handleResize);
@@ -29,12 +22,19 @@ export class WindowSize extends React.Component {
     window.removeEventListener('resize', this.handleResize);
   }
 
+  getWindowSize() {
+    const width = window.innerWidth;
+    const height = window.innerHeight;
+
+    return {width, height};
+  }
+
   setWindowSize = () => {
     const size = this.getWindowSize();
     this.setState(size);
   };
 
-  handleResize = throttle(this.setWindowSize, this.props.throttleMs);
+  handleResize = throttle(this.setWindowSize, this.props.wait);
 
   render() {
     return this.props.children({...this.state});


### PR DESCRIPTION
Goal: fix layout problem about height 100% on iPad.

The following code, used to set the height of the component to 100% of the screen, does not work on iPad:

```css
{
  height: 100vh;
}
```

The following code works on iPad:

```css
{
  height: -webkit-fill-available;
}
```

However it's more reliable to compute the height of the `<FullHeight>` container using JavaScript. 

The component called `<WindowSize>` provides the size fo the window using a render prop pattern.

```js
<WindowSize>
  {({ height }) => <div style={{ height, width: "100%" }}>{children}</div>}
</WindowSize>
```

 