### PR TITLE
Add `Toaster` for screen notifications (WIP)

### DIFF
--- a/package/src/index.js
+++ b/package/src/index.js
@@ -20,4 +20,5 @@ export * from './rs-input';
 export * from './select';
 export * from './spinner';
 export * from './tabs';
+export * from './toaster';
 export * from './typography';

--- a/package/src/root.js
+++ b/package/src/root.js
@@ -54,6 +54,7 @@ const Wrapper = props => {
             </RadiumStarter>
             {/* Modal element must be mounted inside <Fullscreen> */}
             {app.getModal().createElement()}
+            {app.getToaster().createElement()}
           </Fullscreen>
         </LocaleProvider>
       </AppProvider>

--- a/package/src/toaster/index.js
+++ b/package/src/toaster/index.js
@@ -1,0 +1,5 @@
+export {Toaster, Toaster as default} from './toaster';
+
+// Low-level components used for visual testing in the Playground
+export {ToastContainer} from './toast-container';
+export {Toast} from './toast';

--- a/package/src/toaster/stack.js
+++ b/package/src/toaster/stack.js
@@ -14,10 +14,11 @@ export class Stack extends React.Component {
       <ToastContainer position={position}>
         {stack.map(({id, options}) => {
           const {message: ToastContent, ...otherOptions} = options;
+          const close = toaster.close(id);
 
           return (
-            <Toast key={`toast-${id}`} {...otherOptions} close={toaster.close(id)}>
-              {ToastContent && <ToastContent close={toaster.close(id)} />}
+            <Toast key={`toast-${id}`} {...otherOptions} close={close}>
+              {ToastContent && <ToastContent close={close} />}
             </Toast>
           );
         })}

--- a/package/src/toaster/stack.js
+++ b/package/src/toaster/stack.js
@@ -12,9 +12,8 @@ export class Stack extends React.Component {
 
     return (
       <ToastContainer position={position}>
-        {stack.map(({id, options}) => {
+        {stack.map(({id, options, close}) => {
           const {message: ToastContent, ...otherOptions} = options;
-          const close = toaster.close(id);
 
           return (
             <Toast key={`toast-${id}`} {...otherOptions} close={close}>

--- a/package/src/toaster/stack.js
+++ b/package/src/toaster/stack.js
@@ -1,0 +1,27 @@
+import React from 'react';
+
+import {Toast} from './toast';
+import {ToastContainer} from './toast-container';
+
+export class Stack extends React.Component {
+  render() {
+    const {toaster} = this.props;
+    const {position} = toaster;
+
+    const stack = toaster.getStack();
+
+    return (
+      <ToastContainer position={position}>
+        {stack.map(({id, options}) => {
+          const {message: ToastContent, ...otherOptions} = options;
+
+          return (
+            <Toast key={`toast-${id}`} {...otherOptions} close={toaster.close(id)}>
+              {ToastContent && <ToastContent close={toaster.close(id)} />}
+            </Toast>
+          );
+        })}
+      </ToastContainer>
+    );
+  }
+}

--- a/package/src/toaster/toast-container.js
+++ b/package/src/toaster/toast-container.js
@@ -18,7 +18,8 @@ export class ToastContainer extends React.Component {
       position: 'absolute',
       zIndex: 30000, // the toasts should be on top of anything else
       right: 0,
-      display: 'flex'
+      display: 'flex',
+      padding: '.5rem'
     };
 
     if (position === 'top') {

--- a/package/src/toaster/toast-container.js
+++ b/package/src/toaster/toast-container.js
@@ -3,7 +3,7 @@ import PropTypes from 'prop-types';
 
 export class ToastContainer extends React.Component {
   static propTypes = {
-    position: PropTypes.oneOf(['top', 'hidden']),
+    position: PropTypes.oneOf(['top', 'bottom']),
     children: PropTypes.node
   };
 

--- a/package/src/toaster/toast-container.js
+++ b/package/src/toaster/toast-container.js
@@ -1,0 +1,39 @@
+import React from 'react';
+import PropTypes from 'prop-types';
+
+export class ToastContainer extends React.Component {
+  static propTypes = {
+    position: PropTypes.oneOf(['top', 'hidden']),
+    children: PropTypes.node
+  };
+
+  static defaultProps = {
+    position: 'top'
+  };
+
+  render() {
+    const {position, children} = this.props;
+
+    const style = {
+      position: 'absolute',
+      zIndex: 10000, // should be above the modals
+      right: 0,
+      display: 'flex'
+    };
+
+    if (position === 'top') {
+      Object.assign(style, {
+        top: 0,
+        flexDirection: 'column-reverse'
+      });
+    }
+    if (position === 'bottom') {
+      Object.assign(style, {
+        bottom: 0,
+        flexDirection: 'column'
+      });
+    }
+
+    return <div style={style}>{children}</div>;
+  }
+}

--- a/package/src/toaster/toast-container.js
+++ b/package/src/toaster/toast-container.js
@@ -16,7 +16,7 @@ export class ToastContainer extends React.Component {
 
     const style = {
       position: 'absolute',
-      zIndex: 10000, // should be above the modals
+      zIndex: 30000, // the toasts should be on top of anything else
       right: 0,
       display: 'flex'
     };

--- a/package/src/toaster/toast.js
+++ b/package/src/toaster/toast.js
@@ -1,6 +1,8 @@
 import React from 'react';
 import PropTypes from 'prop-types';
-import {Button, withRadiumStarter} from 'radium-starter';
+import {withRadiumStarter} from 'radium-starter';
+
+import {Button, Col, Row} from '../';
 
 @withRadiumStarter
 export class Toast extends React.Component {
@@ -31,7 +33,7 @@ export class Toast extends React.Component {
   startTimeout = () => {
     const {closeAfter, close} = this.props;
 
-    if (closeAfter) {
+    if (closeAfter && !this.autoCloseTimeout) {
       this.autoCloseTimeout = setTimeout(() => close(undefined), closeAfter);
     }
   };
@@ -39,6 +41,7 @@ export class Toast extends React.Component {
   clearTimeout = () => {
     if (this.autoCloseTimeout) {
       clearTimeout(this.autoCloseTimeout);
+      this.autoCloseTimeout = undefined;
     }
   };
 
@@ -51,14 +54,22 @@ export class Toast extends React.Component {
   };
 
   render() {
-    const {title, primaryButton, secondaryButton, children, style, styles: s} = this.props;
+    const {
+      title,
+      primaryButton,
+      secondaryButton,
+      children,
+      style,
+      styles: s,
+      theme: t
+    } = this.props;
 
     const toastStyle = {
-      backgroundColor: 'white',
-      padding: '1rem',
       margin: '.5rem',
+      padding: '1rem',
       minWidth: '300px',
       maxWidth: '450px',
+      backgroundColor: t.backgroundColor,
       boxShadow: 'rgba(0, 0, 0, 0.5) 0px 4px 16px',
       ...s.rounded
     };
@@ -69,13 +80,13 @@ export class Toast extends React.Component {
         onMouseEnter={this.handleMouseEnter}
         onMouseLeave={this.handleMouseLeave}
       >
-        {title && <div style={{fontSize: '1.2rem', marginBottom: '.5rem'}}>{title}</div>}
+        {title && <div style={{fontSize: t.largeFontSize, marginBottom: '.5rem'}}>{title}</div>}
         {children}
         {(primaryButton || secondaryButton) && (
-          <div style={{display: 'flex', marginLeft: '-1rem'}}>
+          <Row style={{marginTop: '1rem'}}>
             {secondaryButton && this.renderButton({...secondaryButton})}
             {primaryButton && this.renderButton({...primaryButton, isPrimary: true})}
-          </div>
+          </Row>
         )}
       </div>
     );
@@ -85,7 +96,7 @@ export class Toast extends React.Component {
     const {close} = this.props;
 
     return (
-      <div style={{width: '100%', padding: '1rem 0 0 1rem'}}>
+      <Col style={{flexGrow: 1}}>
         <Button
           onClick={() => close(value)}
           rsPrimary={isPrimary}
@@ -96,7 +107,7 @@ export class Toast extends React.Component {
         >
           {title}
         </Button>
-      </div>
+      </Col>
     );
   }
 }

--- a/package/src/toaster/toast.js
+++ b/package/src/toaster/toast.js
@@ -1,0 +1,100 @@
+import React from 'react';
+import PropTypes from 'prop-types';
+import {Button, withRadiumStarter} from 'radium-starter';
+import compact from 'lodash/compact';
+
+@withRadiumStarter
+export class Toast extends React.Component {
+  static propTypes = {
+    close: PropTypes.func.isRequired,
+    title: PropTypes.oneOfType([PropTypes.string, PropTypes.func]),
+    primaryButton: PropTypes.object,
+    secondaryButton: PropTypes.object,
+    closeAfter: PropTypes.number,
+    style: PropTypes.object.isRequired,
+    theme: PropTypes.object.isRequired,
+    styles: PropTypes.object.isRequired,
+    children: PropTypes.node
+  };
+
+  static defaultProps = {
+    closeAfter: 5000 // automatically close the toast after 5 seconds
+  };
+
+  componentDidMount() {
+    this.startTimeout();
+  }
+
+  componentWillUnmount() {
+    this.clearTimeout();
+  }
+
+  startTimeout = () => {
+    const {closeAfter, close} = this.props;
+
+    if (closeAfter) {
+      this.autoCloseTimeout = setTimeout(() => close(undefined), closeAfter);
+    }
+  };
+
+  clearTimeout = () => {
+    if (this.autoCloseTimeout) {
+      clearTimeout(this.autoCloseTimeout);
+    }
+  };
+
+  handleMouseEnter = () => {
+    this.clearTimeout();
+  };
+
+  handleMouseLeave = () => {
+    this.startTimeout();
+  };
+
+  render() {
+    const {title, primaryButton, secondaryButton, close, style, styles: s, children} = this.props;
+
+    const toastStyle = {
+      backgroundColor: '#174eb6', // TODO use the theme
+      color: 'rgba(255, 255, 255, 0.85)',
+      padding: '1rem',
+      margin: '.5rem',
+      minWidth: '400px',
+      boxShadow: 'rgba(0, 0, 0, 0.16) 0px 4px 16px',
+      ...s.rounded
+    };
+
+    const buttons = compact([primaryButton, secondaryButton]);
+
+    return (
+      <div
+        style={{...toastStyle, ...style}}
+        onMouseEnter={this.handleMouseEnter}
+        onMouseLeave={this.handleMouseLeave}
+      >
+        {title && <div style={{fontSize: '1.2rem', color: 'white'}}>{title}</div>}
+        {children}
+        {buttons.length > 0 && (
+          <div style={{display: 'flex', marginTop: '1rem'}}>
+            {buttons.map(({title, value}, index) => {
+              const isLast = index === buttons.length - 1;
+              return (
+                <Button
+                  key={index}
+                  onClick={() => close(value)}
+                  style={{
+                    display: 'block',
+                    width: '100%',
+                    marginRight: !isLast ? '1rem' : undefined
+                  }}
+                >
+                  {title}
+                </Button>
+              );
+            })}
+          </div>
+        )}
+      </div>
+    );
+  }
+}

--- a/package/src/toaster/toast.js
+++ b/package/src/toaster/toast.js
@@ -1,7 +1,6 @@
 import React from 'react';
 import PropTypes from 'prop-types';
 import {Button, withRadiumStarter} from 'radium-starter';
-import compact from 'lodash/compact';
 
 @withRadiumStarter
 export class Toast extends React.Component {
@@ -52,19 +51,17 @@ export class Toast extends React.Component {
   };
 
   render() {
-    const {title, primaryButton, secondaryButton, close, style, styles: s, children} = this.props;
+    const {title, primaryButton, secondaryButton, style, styles: s, children} = this.props;
 
     const toastStyle = {
-      backgroundColor: '#174eb6', // TODO use the theme
-      color: 'rgba(255, 255, 255, 0.85)',
+      backgroundColor: 'white',
       padding: '1rem',
       margin: '.5rem',
-      minWidth: '400px',
-      boxShadow: 'rgba(0, 0, 0, 0.16) 0px 4px 16px',
+      minWidth: '300px',
+      maxWidth: '450px',
+      boxShadow: 'rgba(0, 0, 0, 0.5) 0px 4px 16px',
       ...s.rounded
     };
-
-    const buttons = compact([primaryButton, secondaryButton]);
 
     return (
       <div
@@ -72,28 +69,33 @@ export class Toast extends React.Component {
         onMouseEnter={this.handleMouseEnter}
         onMouseLeave={this.handleMouseLeave}
       >
-        {title && <div style={{fontSize: '1.2rem', color: 'white'}}>{title}</div>}
+        {title && <div style={{fontSize: '1.2rem', marginBottom: '.5rem'}}>{title}</div>}
         {children}
-        {buttons.length > 0 && (
-          <div style={{display: 'flex', marginTop: '1rem'}}>
-            {buttons.map(({title, value}, index) => {
-              const isLast = index === buttons.length - 1;
-              return (
-                <Button
-                  key={index}
-                  onClick={() => close(value)}
-                  style={{
-                    display: 'block',
-                    width: '100%',
-                    marginRight: !isLast ? '1rem' : undefined
-                  }}
-                >
-                  {title}
-                </Button>
-              );
-            })}
+        {(primaryButton || secondaryButton) && (
+          <div style={{display: 'flex', marginLeft: '-1rem'}}>
+            {secondaryButton && this.renderButton({...secondaryButton})}
+            {primaryButton && this.renderButton({...primaryButton, isPrimary: true})}
           </div>
         )}
+      </div>
+    );
+  }
+
+  renderButton({title, value, isPrimary}) {
+    const {close} = this.props;
+
+    return (
+      <div style={{width: '100%', padding: '1rem 0 0 1rem'}}>
+        <Button
+          onClick={() => close(value)}
+          rsPrimary={isPrimary}
+          style={{
+            display: 'block',
+            width: '100%'
+          }}
+        >
+          {title}
+        </Button>
       </div>
     );
   }

--- a/package/src/toaster/toast.js
+++ b/package/src/toaster/toast.js
@@ -11,9 +11,9 @@ export class Toast extends React.Component {
     secondaryButton: PropTypes.object,
     closeAfter: PropTypes.number,
     style: PropTypes.object.isRequired,
+    children: PropTypes.node,
     theme: PropTypes.object.isRequired,
-    styles: PropTypes.object.isRequired,
-    children: PropTypes.node
+    styles: PropTypes.object.isRequired
   };
 
   static defaultProps = {
@@ -51,7 +51,7 @@ export class Toast extends React.Component {
   };
 
   render() {
-    const {title, primaryButton, secondaryButton, style, styles: s, children} = this.props;
+    const {title, primaryButton, secondaryButton, children, style, styles: s} = this.props;
 
     const toastStyle = {
       backgroundColor: 'white',

--- a/package/src/toaster/toaster.js
+++ b/package/src/toaster/toaster.js
@@ -1,0 +1,54 @@
+import React from 'react';
+import Base from '@ministate/base';
+import subscribe from '@ministate/react';
+
+import {Stack} from './stack';
+
+export class Toaster extends Base {
+  constructor({position} = {}) {
+    super();
+    this.position = position;
+    this.state = {
+      stack: new Map()
+    };
+  }
+
+  nextToastId = 0; // will be incremented every time a toast is added to the stack
+
+  createElement() {
+    return React.createElement(subscribe(this)(Stack), {toaster: this});
+  }
+
+  notify(title, options) {
+    options = normalizeToastOptions(title, options);
+    return new Promise(resolve => {
+      this.state.stack.set(this.nextToastId, {options, resolve});
+      this.nextToastId++;
+      this.publish();
+    });
+  }
+
+  close = id => value => {
+    const {stack} = this.state;
+
+    const toast = stack.get(id);
+    const {resolve} = toast;
+
+    stack.delete(id);
+    this.publish();
+    resolve(value);
+  };
+
+  getStack() {
+    const {stack} = this.state;
+
+    return Array.from(stack.entries()).map(([id, value]) => ({id, ...value}));
+  }
+}
+
+function normalizeToastOptions(message, options) {
+  return {
+    message: typeof message === 'function' ? message : () => message,
+    ...options
+  };
+}

--- a/package/src/toaster/toaster.js
+++ b/package/src/toaster/toaster.js
@@ -19,30 +19,33 @@ export class Toaster extends Base {
     return React.createElement(subscribe(this)(Stack), {toaster: this});
   }
 
-  notify(title, options) {
-    options = normalizeToastOptions(title, options);
+  notify(message, options) {
+    options = normalizeToastOptions(message, options);
     return new Promise(resolve => {
-      this.state.stack.set(this.nextToastId, {options, resolve});
+      const id = this.nextToastId;
+
+      const close = value => {
+        this._close(id);
+        resolve(value);
+      };
+
+      this.state.stack.set(id, {id, options, close});
       this.nextToastId++;
       this.publish();
     });
   }
 
-  close = id => value => {
+  _close = id => {
     const {stack} = this.state;
-
-    const toast = stack.get(id);
-    const {resolve} = toast;
 
     stack.delete(id);
     this.publish();
-    resolve(value);
   };
 
   getStack() {
     const {stack} = this.state;
 
-    return Array.from(stack.entries()).map(([id, value]) => ({id, ...value}));
+    return Array.from(stack.values());
   }
 }
 

--- a/playground/src/components/root.js
+++ b/playground/src/components/root.js
@@ -3,7 +3,7 @@ import '@babel/polyfill'; // fix build error `regeneratorRuntime is not defined`
 import React from 'react';
 import PropTypes from 'prop-types';
 import {createBaseApp} from '@medmain/base-frontend';
-import {Root as BaseRoot, Modal} from '@medmain/react-ui-kit';
+import {Root as BaseRoot, Modal, Toaster} from '@medmain/react-ui-kit';
 
 import {englishLocale} from '../locales/english';
 
@@ -13,14 +13,18 @@ const locales = {
 
 const App = createBaseApp({productId: 'demo', locales});
 const app = new App();
-const modal = new Modal();
 
-const Root = ({children}) => (
-  <BaseRoot app={app}>
-    {modal.createElement()}
-    {typeof children === 'function' ? children({app, modal}) : children}
-  </BaseRoot>
-);
+const Root = ({children}) => {
+  const modal = new Modal();
+  const toaster = new Toaster({placement: 'top'});
+  return (
+    <BaseRoot app={app}>
+      {modal.createElement()}
+      {toaster.createElement()}
+      {typeof children === 'function' ? children({app, modal, toaster}) : children}
+    </BaseRoot>
+  );
+};
 Root.propTypes = {
   children: PropTypes.oneOfType([PropTypes.node, PropTypes.func]).isRequired
 };

--- a/playground/src/components/toaster-demo.js
+++ b/playground/src/components/toaster-demo.js
@@ -1,0 +1,30 @@
+/* eslint-disable react/display-name, react/prop-types */
+import React from 'react';
+import {Button} from '@medmain/react-ui-kit';
+
+export async function showSimpleToast(toaster) {
+  const answer = await toaster.notify(
+    ({close}) => (
+      <div>
+        Don't think twice, it's alright! <Button onClick={() => close('OK')}>Close</Button>
+      </div>
+    ),
+    {
+      title: 'Custom message'
+    }
+  );
+  console.info({answer});
+}
+
+export async function showAppUpdateToast(toaster) {
+  const answer = await toaster.notify(
+    'An update is available, click on the "Update" button to reload the page.',
+    {
+      title: 'Application update',
+      primaryButton: {title: 'Update', value: true},
+      secondaryButton: {title: 'Not now', value: false},
+      closeAfter: 0
+    }
+  );
+  console.info({answer});
+}

--- a/playground/src/components/toaster-demo.js
+++ b/playground/src/components/toaster-demo.js
@@ -7,6 +7,9 @@ export async function showSimpleToast(toaster) {
     ({close}) => (
       <div>
         Don't think twice, it's alright! <Button onClick={() => close('OK')}>Close</Button>
+        <br />
+        This is an example of long content, that will be displayed on several lines because the
+        width of the "toast" is limited.
       </div>
     ),
     {

--- a/playground/src/docs/toaster.mdx
+++ b/playground/src/docs/toaster.mdx
@@ -21,13 +21,13 @@ Default placement: at the top
     <VerticalContainer height={400}>
       <ToastContainer>
         <Toast close={console.log}>First message: it worked!</Toast>
-        <Toast close={console.log} title="Success">
+        <Toast close={console.log} title="Success" secondaryButton={{title: 'OK', value: true}}>
           Second message: it worked!
         </Toast>
         <Toast
           title={'App update'}
-          primaryButton={{title: 'Not now', value: false}}
-          secondaryButton={{title: 'Update', value: true}}
+          primaryButton={{title: 'Update', value: true}}
+          secondaryButton={{title: 'Not now', value: false}}
           close={console.log}
         >
           An update is available, click on the "Update" button to reload the page.
@@ -42,7 +42,7 @@ At the bottom
 <Playground>
   <Root>
     <VerticalContainer height={400}>
-      <ToastContainer placement="bottom">
+      <ToastContainer position="bottom">
         <Toast close={console.log}>It worked</Toast>
         <Toast close={console.log} title="Success">
           Second message: it worked!

--- a/playground/src/docs/toaster.mdx
+++ b/playground/src/docs/toaster.mdx
@@ -1,0 +1,114 @@
+---
+route: /toaster
+name: Toaster
+---
+
+import {Playground} from 'docz';
+import {ToastContainer, Toast, Button} from '@medmain/react-ui-kit';
+
+import Root from '../components/root';
+import {VerticalContainer} from '../components/vertical-container';
+import {showSimpleToast, showAppUpdateToast} from '../components/toaster-demo';
+
+# Toaster
+
+## Toast component
+
+Default placement: at the top
+
+<Playground>
+  <Root>
+    <VerticalContainer height={400}>
+      <ToastContainer>
+        <Toast close={console.log}>First message: it worked!</Toast>
+        <Toast close={console.log} title="Success">
+          Second message: it worked!
+        </Toast>
+        <Toast
+          title={'App update'}
+          primaryButton={{title: 'Not now', value: false}}
+          secondaryButton={{title: 'Update', value: true}}
+          close={console.log}
+        >
+          An update is available, click on the "Update" button to reload the page.
+        </Toast>
+      </ToastContainer>
+    </VerticalContainer>
+  </Root>
+</Playground>
+
+At the bottom
+
+<Playground>
+  <Root>
+    <VerticalContainer height={400}>
+      <ToastContainer placement="bottom">
+        <Toast close={console.log}>It worked</Toast>
+        <Toast close={console.log} title="Success">
+          Second message: it worked!
+        </Toast>
+      </ToastContainer>
+    </VerticalContainer>
+  </Root>
+</Playground>
+
+## Imperative API
+
+The API is vaguely inspired by:
+
+- The browser native [notification API](https://developer.mozilla.org/en-US/docs/Web/API/notification)
+- [_node-notifier_ package](https://www.npmjs.com/package/node-notifier)
+
+```js
+const toaster = new Toaster({position: 'TOP'});
+await toaster.notify(message, options);
+```
+
+The `notify` method returns a Promise that resolves with:
+
+- either `undefined` if the toast closes automatically after the timeout
+- or the `value` assigned to the button clicked by the user.
+
+### Available options
+
+- `title`
+- `buttons`
+- `closeAfter`: 5000 by defaut (5 seconds), the toast stays on the screen if it's `0`.
+
+### Examples
+
+The simplest example, passing only a string to `notify` method
+
+<Playground>
+  <Root>
+    {({toaster}) => (
+      <VerticalContainer height={300}>
+        <Button onClick={() => toaster.notify('Success!')}>Show message</Button>
+      </VerticalContainer>
+    )}
+  </Root>
+</Playground>
+
+Toast with custom content, using the `close` callback
+
+<Playground>
+  <Root>
+    {({toaster}) => (
+      <VerticalContainer height={300}>
+        <Button onClick={() => showSimpleToast(toaster)}>Show message</Button>
+      </VerticalContainer>
+    )}
+  </Root>
+</Playground>
+
+Toast with 2 buttons and `requireInteraction` option: it remains active until the user clicks or dismisses it.
+
+<Playground>
+  <Root>
+    {({toaster}) => (
+      <VerticalContainer height={300}>
+        <Button onClick={() => showAppUpdateToast(toaster)}>Show message</Button>
+      </VerticalContainer>
+    )}
+  </Root>
+</Playground>

--- a/playground/src/docs/toaster.mdx
+++ b/playground/src/docs/toaster.mdx
@@ -101,7 +101,7 @@ Toast with custom content, using the `close` callback
   </Root>
 </Playground>
 
-Toast with 2 buttons and `requireInteraction` option: it remains active until the user clicks or dismisses it.
+Toast with 2 buttons and `closeAfter` option set to `0`: the toast stays "open" until the user clicks one of the buttons.
 
 <Playground>
   <Root>


### PR DESCRIPTION
Goal: add a component to set non intrusive notifications on the screen.

See the online demo: https://medmain-playground.surge.sh/toaster

### API preview

```js
const toaster = new Toaster({position: 'TOP'});

const answer = await toaster.notify(
  'An update is available, click on the "Update" button to reload the page.',
  {
    title: 'Application update',
    primaryButton: {title: 'Update', value: true},
    secondaryButton: {title: 'Not now', value: false},
    closeAfter: 0
  }
);
console.info({answer});
```

### To do

- [ ] improve the design (action buttons)
- [ ] add an `icon` option?